### PR TITLE
Lowercase username from state when sending to 2FA

### DIFF
--- a/client/src/component/Login/SecondFactorForm.tsx
+++ b/client/src/component/Login/SecondFactorForm.tsx
@@ -102,6 +102,6 @@ export default class SecondFactorForm extends React.Component<FormProps, FormSta
 
         const token = tokenParts.join(' ');
 
-        login2F(this.props.username, token);
+        login2F(this.props.username.toLowerCase(), token);
     }
 }


### PR DESCRIPTION
@teaforthecat helped me find the right place to do this on the client side because I wasn't getting anywhere with the Java classes. 

It doesn't need to be lowercased for the first factor because that is handled at the DB level, but it doesn't seem to work for the 2FA.

After the first login, the user sees `Enter challenge for user: COUNTYADMIN15` above the 2FA inputs -- so if we lowercased on the first factor, what they see here would change and would not match what they entered.