### PR TITLE
[wip] Select ballots based on BallotManifestInfo, not CVR data

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -513,7 +513,20 @@ public final class Main {
     
     return sb.toString();
   }
-  
+
+
+  /**
+   * find property value and coerce to boolean or return defaultValue if not found
+   **/
+  public static boolean getBooleanProperty(final String propName, final Boolean defaultValue) {
+    final String v = static_properties.getProperty(propName);
+    if (v == null) {
+      return defaultValue;
+    } else {
+      return Boolean.parseBoolean(v);
+    }
+  }
+
   /**
    * Starts a ColoradoRLA server.
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -1,0 +1,120 @@
+/**
+ * Prepare a list of ballot information from a list of random numbers
+ **/
+package us.freeandfair.corla.controller;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import us.freeandfair.corla.json.CVRToAuditResponse;
+import us.freeandfair.corla.model.BallotManifestInfo;
+import us.freeandfair.corla.model.CastVoteRecord;
+import us.freeandfair.corla.query.BallotManifestInfoQueries;
+import us.freeandfair.corla.query.CastVoteRecordQueries;
+
+public final class BallotSelection {
+
+  private BallotSelection() {
+  }
+
+  /**
+   * Prepare a list of ballot information from random numbers. Asks the
+   * ballot_manifest_info table for info and joins in some info from
+   * cast_vote_records. We are very intentional about the source of data coming
+   * from the ballot_manifest_info and not the cast_vote_records. The
+   * cast_vote_records info is merged in as a convenience to find discrepancies
+   * as early as possible.
+   **/
+  public static List<CVRToAuditResponse> selectBallots(final List<Long> rands) {
+    return selectBallots(rands,
+                         BallotSelection::queryBallotManifestInfos,
+                         BallotSelection::queryCastVoteRecords);
+  }
+
+  /**
+   * same as above with optional dependency injection
+   **/
+  public static List<CVRToAuditResponse>
+      selectBallots(final List<Long> rands,
+                    final Function<Long,Optional<BallotManifestInfo>> queryBMI,
+                    final Function<List<Long>,List<CastVoteRecord>> queryCVR) {
+    final List<CVRToAuditResponse> a_list = new LinkedList<CVRToAuditResponse>();
+    // here we rely on the id of the cvr to match the audit_sequence_number.
+    // This is done by incrementing a counter during the file import.
+    final List<CastVoteRecord> cvrs = queryCVR.apply(rands);
+
+    int i = 0;
+    for (final Long rand: rands) {
+      i++;
+      final Optional<BallotManifestInfo> bmiMaybe = queryBMI.apply(rand);
+
+      CastVoteRecord cvr;
+      try {
+        cvr = cvrs.get(i - 1); // index is 0 based
+      } catch (final IndexOutOfBoundsException e) {
+        // TODO create a warning or a discrepancy of some kind
+        cvr = new CastVoteRecord();
+      }
+
+      if (bmiMaybe.isPresent()) {
+        a_list.add(toResponse(i, rand, bmiMaybe.get(), cvr));
+      } else {
+        final String msg = "could not find a ballot manifest for random number: " +
+            rand.toString();
+        throw new BallotSelection.MissingBallotManifestException(msg);
+      }
+    }
+    return a_list;
+  }
+
+  /**
+   * get ready to render the data
+   **/
+  public static CVRToAuditResponse toResponse(final int the_audit_sequence_number,
+                                              final Long rand,
+                                              final BallotManifestInfo bmi,
+                                              final CastVoteRecord cvr) {
+
+    return new CVRToAuditResponse(the_audit_sequence_number,
+                                  bmi.scannerID(),
+                                  bmi.batchID(),
+                                  cvr.recordID(),
+                                  bmi.imprintedID(rand),
+                                  cvr.cvrNumber(),
+                                  cvr.id(),
+                                  cvr.ballotType(),
+                                  bmi.storageLocation(),
+                                  cvr.auditFlag());
+  }
+
+  /**
+   * query the database for ballot_manifest_info that would hold the given
+   * random number
+   **/
+  public static Optional<BallotManifestInfo> queryBallotManifestInfos(final Long rand) {
+    return BallotManifestInfoQueries.holdingSequenceNumber(rand);
+  }
+
+  /**
+   * query the database for cast_vote_records with ids that are in the given
+   * list of random numbers
+   **/
+  public static List<CastVoteRecord> queryCastVoteRecords(final List<Long> rands) {
+    return CastVoteRecordQueries.get(rands);
+  }
+
+  /**
+   * this is bad, it could be one of two things:
+   * - a random number was generated outside of the number of ballots
+   * - there is a gap in the sequence_start and sequence_end values of the
+         ballot_manifest_infos
+   **/
+  public static class MissingBallotManifestException extends RuntimeException {
+    /** constructor **/
+    public MissingBallotManifestException(final String msg) {
+      super(msg);
+    }
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -102,7 +102,7 @@ public final class BallotSelection {
     return new CVRToAuditResponse(the_audit_sequence_number,
                                   bmi.scannerID(),
                                   bmi.batchID(),
-                                  cvr.recordID(),
+                                  bmi.ballotPosition(rand).intValue(),
                                   bmi.imprintedID(rand),
                                   cvr.cvrNumber(),
                                   cvr.id(),

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import us.freeandfair.corla.json.CVRToAuditResponse;
+import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
 import us.freeandfair.corla.model.BallotManifestInfo;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.query.BallotManifestInfoQueries;
@@ -66,6 +67,7 @@ public final class BallotSelection {
         throw new BallotSelection.MissingBallotManifestException(msg);
       }
     }
+    a_list.sort(new BallotOrderComparator());
     return a_list;
   }
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/CVRSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/CVRSelection.java
@@ -1,0 +1,60 @@
+/**
+ * Prepare a list of cast vote records
+ **/
+package us.freeandfair.corla.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
+
+import us.freeandfair.corla.json.CVRToAuditResponse;
+import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
+import us.freeandfair.corla.model.CastVoteRecord;
+import us.freeandfair.corla.model.CountyDashboard;
+import us.freeandfair.corla.query.BallotManifestInfoQueries;
+
+public final class CVRSelection {
+
+  private CVRSelection() {
+  }
+
+  /**
+   * Prepare a list of cast vote records
+   **/
+  public static List<CVRToAuditResponse>
+      selectCVRs(final CountyDashboard cdb,
+                 final OptionalInt round_index,
+                 final boolean audited,
+                 final boolean duplicates,
+                 final int ballot_count,
+                 final int index) {
+
+    final List<CVRToAuditResponse> response_list = new ArrayList<>();
+    final List<CastVoteRecord> cvr_to_audit_list;
+
+    if (round_index.isPresent()) {
+      cvr_to_audit_list =
+        ComparisonAuditController.ballotsToAudit(cdb, round_index.getAsInt(), audited);
+    } else {
+      cvr_to_audit_list =
+        ComparisonAuditController.computeBallotOrder(cdb, index, ballot_count,
+                                                     duplicates, audited);
+    }
+
+    for (int i = 0; i < cvr_to_audit_list.size(); i++) {
+      final CastVoteRecord cvr = cvr_to_audit_list.get(i);
+      final String location = BallotManifestInfoQueries.locationFor(cvr);
+      response_list.add(new CVRToAuditResponse(i, cvr.scannerID(),
+                                               cvr.batchID(), cvr.recordID(),
+                                               cvr.imprintedID(),
+                                               cvr.cvrNumber(), cvr.id(),
+                                               cvr.ballotType(), location,
+                                               cvr.auditFlag()));
+    }
+    response_list.sort(new BallotOrderComparator());
+
+    return response_list;
+  }
+
+
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -21,12 +21,14 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.controller.BallotSelection;
 import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.json.CVRToAuditResponse;
 import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
+import us.freeandfair.corla.model.Round;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.BallotManifestInfoQueries;
 
@@ -188,7 +190,7 @@ public class CVRToAuditList extends AbstractEndpoint {
       // get other things we need
       final CountyDashboard cdb = Persistence.getByID(county.id(), CountyDashboard.class);
       final List<CastVoteRecord> cvr_to_audit_list;
-      final List<CVRToAuditResponse> response_list = new ArrayList<>();
+      List<CVRToAuditResponse> response_list = new ArrayList<>();
 
       // compute the round, if any
       OptionalInt round = OptionalInt.empty();
@@ -198,30 +200,43 @@ public class CVRToAuditList extends AbstractEndpoint {
           round = OptionalInt.of(round_number);
         } else {
           badDataContents(the_response, "cvr list requested for invalid round " +
-                                        round_param + " for county " + cdb.id());
+                          round_param + " for county " + cdb.id());
         }
       }
 
-      if (round.isPresent()) {
-        cvr_to_audit_list =
+      // feature flag - for emergencies only - TODO: remove after confidence achieved
+      final boolean use_ballot_manifest_selection = true;
+
+      if (use_ballot_manifest_selection) {
+
+        if (round.isPresent()) {
+          cvr_to_audit_list =
             ComparisonAuditController.ballotsToAudit(cdb, round.getAsInt(), audited);
-      } else {
-        cvr_to_audit_list =
+        } else {
+          cvr_to_audit_list =
             ComparisonAuditController.computeBallotOrder(cdb, index, ballot_count,
                                                          duplicates, audited);
+        }
+
+        for (int i = 0; i < cvr_to_audit_list.size(); i++) {
+          final CastVoteRecord cvr = cvr_to_audit_list.get(i);
+          final String location = BallotManifestInfoQueries.locationFor(cvr);
+          response_list.add(new CVRToAuditResponse(i, cvr.scannerID(),
+                                                   cvr.batchID(), cvr.recordID(),
+                                                   cvr.imprintedID(),
+                                                   cvr.cvrNumber(), cvr.id(),
+                                                   cvr.ballotType(), location,
+                                                   cvr.auditFlag()));
+        }
+        response_list.sort(new BallotOrderComparator());
+      } else {
+        final Round the_round = cdb.rounds().get(round.getAsInt() - 1);
+        // replace the var
+        response_list = BallotSelection.
+          selectBallots(the_round.generatedNumbers());
       }
 
-      for (int i = 0; i < cvr_to_audit_list.size(); i++) {
-        final CastVoteRecord cvr = cvr_to_audit_list.get(i);
-        final String location = BallotManifestInfoQueries.locationFor(cvr);
-        response_list.add(new CVRToAuditResponse(i, cvr.scannerID(),
-                                                 cvr.batchID(), cvr.recordID(),
-                                                 cvr.imprintedID(),
-                                                 cvr.cvrNumber(), cvr.id(),
-                                                 cvr.ballotType(), location,
-                                                 cvr.auditFlag()));
-      }
-      response_list.sort(new BallotOrderComparator());
+
       okJSON(the_response, Main.GSON.toJson(response_list));
     } catch (final PersistenceException e) {
       serverError(the_response, "could not generate cvr list");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
@@ -223,10 +223,19 @@ public class BallotManifestInfo implements PersistentEntity, Serializable {
    **/
   public String imprintedID(final Long rand) {
     // offset is the nth (1 based)
-    final Long offset = rand - sequenceStart() + 1L;
+    final Long offset = ballotPosition(rand);
     return scannerID() + "-" +
            batchID() + "-" +
            offset.toString();
+  }
+
+  /**
+   * computed value based on other values
+   **/
+  public Long ballotPosition(final Long rand) {
+    // offset is the nth (1 based)
+    final Long offset = rand - sequenceStart() + 1L;
+    return offset;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
@@ -219,6 +219,17 @@ public class BallotManifestInfo implements PersistentEntity, Serializable {
   }
 
   /**
+   * computed value based on other values
+   **/
+  public String imprintedID(final Long rand) {
+    // offset is the nth (1 based)
+    final Long offset = rand - sequenceStart() + 1L;
+    return scannerID() + "-" +
+           batchID() + "-" +
+           offset.toString();
+  }
+
+  /**
    * @return a String representation of this object.
    */
   @Override

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -402,7 +402,11 @@ public class Round implements Serializable {
     my_signatories.clear();
     my_signatories.addAll(the_signatories);
   }
-  
+
+  /** stub **/
+  public List<Long> generatedNumbers() {
+    return new ArrayList<Long>();
+  }
   /**
    * @return a String representation of this elector.
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
@@ -171,11 +171,11 @@ public final class BallotManifestInfoQueries {
           cb.createQuery(BallotManifestInfo.class);
       final Root<BallotManifestInfo> root = cq.from(BallotManifestInfo.class);
       final List<Predicate> disjuncts = new ArrayList<Predicate>();
-      final Predicate start = cb.greaterThanOrEqualTo(root.get("my_sequence_start"), the_n);
-      final Predicate end = cb.lessThanOrEqualTo(root.get("my_sequence_end"), the_n);
+      final Predicate start = cb.lessThanOrEqualTo(root.get("my_sequence_start"), the_n);
+      final Predicate end = cb.greaterThanOrEqualTo(root.get("my_sequence_end"), the_n);
       disjuncts.add(start);
       disjuncts.add(end);
-      cq.select(root).where(cb.or(disjuncts.toArray(new Predicate[disjuncts.size()])));
+      cq.select(root).where(cb.and(disjuncts.toArray(new Predicate[disjuncts.size()])));
       final TypedQuery<BallotManifestInfo> query = s.createQuery(cq);
       result = new HashSet<BallotManifestInfo>(query.getResultList());
     } catch (final PersistenceException e) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
@@ -315,7 +315,12 @@ public final class CastVoteRecordQueries {
       final List<Predicate> conjuncts = new ArrayList<>();
       conjuncts.add(cb.equal(root.get(COUNTY_ID), the_county_id));
       conjuncts.add(cb.equal(root.get(RECORD_TYPE), RecordType.UPLOADED));
-      conjuncts.add(root.get("my_sequence_number").in(the_sequence_numbers));
+      // "my_cvr_number" column is is the value from the csv "CvrNumber" (which
+      // is 1 based) so we are counting on this to be sequential. The
+      // "sequence_number" column might also be an option. That is the
+      // my_record_count incremented counter in DominionCVRExportParser. That
+      // number, however, is 0 based and our generated numbers are 1 based
+      conjuncts.add(root.get("my_cvr_number").in(the_sequence_numbers));
       cq.select(root).where(cb.and(conjuncts.toArray(new Predicate[conjuncts.size()])));
       final TypedQuery<CastVoteRecord> query = s.createQuery(cq);
       result = query.getResultList();

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
@@ -22,6 +22,7 @@ public class BallotSelectionTest {
 
   private BallotSelectionTest (){};
 
+  private List<CastVoteRecord> fake_cvrs;
 
   @Test()
   public void testSelectBallotsReturnsListOfOnes(){
@@ -41,6 +42,19 @@ public class BallotSelectionTest {
     Assert.assertEquals(results.get(0).imprintedID(), "1-1-7");
   }
 
+  @Test()
+  public void testSelectBallotsReturnsPhantomRecord(){
+    Long rand = 47L;
+    Long sequence_start = 41L;
+    // overwrite var
+    fake_cvrs = new ArrayList<CastVoteRecord>();
+    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(results.get(0).imprintedID(), "1-1-7");
+    Assert.assertEquals(results.get(0).ballotType(), "");
+    Assert.assertEquals(results.get(0).cvrNumber(), 0);
+  }
+
   private List<CVRToAuditResponse> makeSelection(Long rand, Long sequence_start) {
     // setup
     Long sequence_end = rand - sequence_start + 1L;
@@ -50,17 +64,21 @@ public class BallotSelectionTest {
     BallotManifestInfo bmi = fakeBMI(sequence_start, sequence_end);
     List<CastVoteRecord> cvrs = fakeCVRs();
     Function<Long,Optional<BallotManifestInfo>> query = (Long r) -> Optional.of(bmi);
-    Function<List<Long>,List<CastVoteRecord>> queryCVRs = (List<Long> l) -> cvrs;
+    BallotSelection.CVRQ queryCVRs = (List<Long> l, Long c) -> cvrs;
 
     // subject under test
-    return BallotSelection.selectBallots(rands, query, queryCVRs);
+    return BallotSelection.selectBallots(rands, 0L, query, queryCVRs);
   }
 
   public List<CastVoteRecord> fakeCVRs(){
-    List<CastVoteRecord> cvrs = new LinkedList<CastVoteRecord>();
-    CastVoteRecord cvr1 = fakeCVR();
-    cvrs.add(cvr1);
-    return cvrs;
+    if (fake_cvrs != null) {
+      return fake_cvrs;
+    } else {
+      List<CastVoteRecord> cvrs = new LinkedList<CastVoteRecord>();
+      CastVoteRecord cvr1 = fakeCVR();
+      cvrs.add(cvr1);
+      return cvrs;
+    }
   }
 
   public CastVoteRecord fakeCVR() {

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
@@ -1,0 +1,96 @@
+package us.freeandfair.corla.controllers;
+
+import us.freeandfair.corla.controller.BallotSelection;
+import us.freeandfair.corla.json.CVRToAuditResponse;
+import us.freeandfair.corla.model.BallotManifestInfo;
+import us.freeandfair.corla.model.CastVoteRecord;
+import us.freeandfair.corla.persistence.Persistence;
+
+import java.time.Instant;
+
+import java.util.ArrayList;
+import java.util.function.Function;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class BallotSelectionTest {
+
+
+  private BallotSelectionTest (){};
+
+
+  @Test()
+  public void testSelectBallotsReturnsListOfOnes(){
+    Long rand = 1L;
+    Long sequence_start = 1L;
+    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(results.get(0).imprintedID(), "1-1-1");
+  }
+
+  @Test()
+  public void testSelectBallotsReturnsListHappyPath(){
+    Long rand = 47L;
+    Long sequence_start = 41L;
+    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(results.get(0).imprintedID(), "1-1-7");
+  }
+
+  private List<CVRToAuditResponse> makeSelection(Long rand, Long sequence_start) {
+    // setup
+    Long sequence_end = rand - sequence_start + 1L;
+    List<Long> rands = new ArrayList<Long>();
+    rands.add(rand);
+
+    BallotManifestInfo bmi = fakeBMI(sequence_start, sequence_end);
+    List<CastVoteRecord> cvrs = fakeCVRs();
+    Function<Long,Optional<BallotManifestInfo>> query = (Long r) -> Optional.of(bmi);
+    Function<List<Long>,List<CastVoteRecord>> queryCVRs = (List<Long> l) -> cvrs;
+
+    // subject under test
+    return BallotSelection.selectBallots(rands, query, queryCVRs);
+  }
+
+  public List<CastVoteRecord> fakeCVRs(){
+    List<CastVoteRecord> cvrs = new LinkedList<CastVoteRecord>();
+    CastVoteRecord cvr1 = fakeCVR();
+    cvrs.add(cvr1);
+    return cvrs;
+  }
+
+  public CastVoteRecord fakeCVR() {
+    Instant now = Instant.now();
+    CastVoteRecord cvr = new CastVoteRecord(CastVoteRecord.RecordType.UPLOADED,
+                                            now,
+                                            64L, // county_id
+                                            1,  // cvr_number
+                                            1, // sequence_number
+                                            1, // scanner_id
+                                            "Batch1", // batch_id
+                                            1, // record_id
+                                            "1-Batch1-1", // imprinted_id
+                                            "paper", // ballot_type
+                                            null  // contest_info
+                                            );
+
+    cvr.setID(1L);
+    return cvr;
+  }
+
+  public BallotManifestInfo fakeBMI(Long sequence_start,Long sequence_end){
+    BallotManifestInfo bmi = new BallotManifestInfo(1L,      // county_id
+                                                    1,       // scanner_id
+                                                    "1",     // batch_id
+                                                    1,       // batch_size
+                                                    "bin-1", // storage_location
+                                                    sequence_start,       // sequence_start
+                                                    sequence_end        // sequence_end
+                                                    );
+    return bmi;
+  }
+}


### PR DESCRIPTION
Depends on the Round having stored random numbers.
We'll merge this after the `store-independent-random-sequence` branch, but we can start a review.