### PR TITLE
Lowercase username parameter to login2F

### DIFF
--- a/client/src/component/Login/SecondFactorForm.tsx
+++ b/client/src/component/Login/SecondFactorForm.tsx
@@ -88,6 +88,6 @@ export default class SecondFactorForm extends React.Component<FormProps, FormSta
 
     private buttonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
         const { username, token } = this.state.form;
-        login2F(this.props.username, token);
+        login2F(this.props.username.toLowerCase(), token);
     }
 }


### PR DESCRIPTION
As we observed in CO, users attempting to log in with a non-lowercase username were stymied on the second factor log-in form. When the user enters their username as lowercase, both first- and second- factor forms work as expected. It stands to reason that we need to lowercase the username on both forms, since that would provide the same result as if the user had initially entered their username in lowercase.