### PR TITLE
Use Docker multi-stage builds for client and server

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,7 +12,6 @@ SERVER_TAG ?= latest
 .PHONY: httpd-build httpd-deploy
 
 httpd-build:
-	cd ../client; npm install; npm run dist
 	docker build -f httpd/Dockerfile -t $(HTTPD_REPOSITORY):$(HTTPD_TAG) ../
 
 httpd-deploy:
@@ -33,8 +32,6 @@ postgresql-deploy:
 .PHONY: server-build server-deploy
 
 server-build:
-
-	cd ../server/eclipse-project; mvn package
 	docker build -f server/Dockerfile -t $(SERVER_REPOSITORY):$(SERVER_TAG) \
 		--build-arg VERSION=$(shell cd ../server/eclipse-project; mvn help:evaluate -Dexpression=project.version | grep '^[[:digit:]].\+') \
 		../

--- a/docker/README.markdown
+++ b/docker/README.markdown
@@ -19,8 +19,6 @@ use.
 
 - `make` if you want to use the Makefile targets
 - `docker` for building and deploying Docker images
-- `mvn` (Maven) for building the RLA server
-- `npm` (node.js) for building the frontend
 
 ## Services
 
@@ -80,7 +78,6 @@ You may set the following environment variables for `make`:
 
 - `SERVER_REPOSITORY`: Docker repository for the built image
 - `SERVER_TAG`: Docker image tag for the built image
-- `SERVER_VERSION`: The version of the RLA server (name of the JAR)
 
 #### Building
 

--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -1,6 +1,11 @@
+FROM node:8 as node
+
+COPY client /srv/corla/client
+RUN cd /srv/corla/client && npm install && npm run dist
+
 FROM httpd:2.4
 LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
 
 COPY docker/httpd/httpd.conf /usr/local/apache2/conf/
 COPY docker/httpd/corla.conf /usr/local/apache2/conf/extra/
-COPY client/dist /srv/corla/client/dist
+COPY --from=node /srv/corla/client/dist /srv/corla/client/dist

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,3 +1,8 @@
+FROM maven:3 as maven
+
+COPY server/eclipse-project /srv/corla/server/eclipse-project
+RUN cd /srv/corla/server/eclipse-project && mvn package
+
 FROM openjdk:8
 LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
 
@@ -6,7 +11,7 @@ ARG VERSION
 ## TODO: How can we architect this such that passing -Dthe.prop=value works as
 ## expected?
 COPY docker/server/docker.properties /srv/corla/docker.properties
-COPY server/eclipse-project/target/colorado_rla-${VERSION}-shaded.jar \
+COPY --from=maven /srv/corla/server/eclipse-project/target/colorado_rla-${VERSION}-shaded.jar \
      /srv/corla/corla.jar
 
 CMD ["java", \


### PR DESCRIPTION
Building in a Dockerized environment helps isolate build-time dependencies and removes the requirement to have Node or Maven installed to build the client or the server.

- [Documentation for multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)