### PR TITLE
Select ballots from manifest info

### DIFF
--- a/server/eclipse-project/project_configuration/freeandfair_checkstyle.xml
+++ b/server/eclipse-project/project_configuration/freeandfair_checkstyle.xml
@@ -15,10 +15,6 @@
     <module name="ConstantName">
       <message key="name.invalidPattern" value="Constant ''{0}'' must be named IN_ALL_UPPER_CASE_WITH_UNDERSCORES."/>
     </module>
-    <module name="MemberName">
-      <property name="format" value="^my_[a-z0-9]*(_[a-z0-9]+)*$"/>
-      <message key="name.invalidPattern" value="Instance field ''{0}'' must start with &quot;my_&quot; and contain only lowercase letters, numbers, and underscores."/>
-    </module>
     <module name="MethodName">
       <message key="name.invalidPattern" value="Method name &quot;{0}&quot; must start with a lowercase letter and contain only letters and numbers."/>
       <message key="method.name.equals.class.name" value="Method name ''{0}'' must not equal the enclosing class name."/>
@@ -84,7 +80,7 @@
     </module>
     <module name="OperatorWrap">
       <property name="option" value="eol"/>
-      <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,GT,LAND,LE,LITERAL_INSTANCEOF,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,SL,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN"/>
+      <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,GT,LAND,LE,LITERAL_INSTANCEOF,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS_ASSIGN,QUESTION,SL,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN"/>
     </module>
     <module name="MethodParamPad">
       <property name="allowLineBreaks" value="true"/>

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -3,16 +3,10 @@
  **/
 package us.freeandfair.corla.controller;
 
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-
-import us.freeandfair.corla.json.CVRToAuditResponse;
-import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
 import us.freeandfair.corla.model.BallotManifestInfo;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.query.BallotManifestInfoQueries;
@@ -23,69 +17,11 @@ public final class BallotSelection {
   /** prevent construction **/
   private BallotSelection() {
   }
-
-  /**
-   * Prepare a list of ballots from random numbers. Asks the
-   * ballot_manifest_info table for info and joins in some info from
-   * cast_vote_records. We are very intentional about the source of data coming
-   * from the ballot_manifest_info and not the cast_vote_records. The
-   * cast_vote_records info is merged in as a convenience to find discrepancies
-   * as early as possible.
-   **/
-  public static List<CVRToAuditResponse> selectBallots(final List<Long> rands,
-                                                       final Long countyID) {
-    return selectBallots(rands,
-                         countyID,
-                         BallotManifestInfoQueries::holdingSequenceNumber,
-                         CastVoteRecordQueries::atPosition);
-  }
-
-  /**
-   * same as above with optional dependency injection
-   **/
-  public static List<CVRToAuditResponse>
-      selectBallots(final List<Long> rands,
-                    final Long countyID,
-                    final BMIQ queryBMI,
-                    final CVRQ queryCVR) {
-
-    // this is what gets added to and returned
-    final List<CVRToAuditResponse> responses = new LinkedList<CVRToAuditResponse>();
-
-    Integer audit_sequence_number = 0;
-    for (final Long rand: rands) {
-      // could we get them all at once? I'm not sure
-      final Optional<BallotManifestInfo> bmiMaybe = queryBMI.apply(rand,countyID);
-      CastVoteRecord cvr;
-
-      if (bmiMaybe.isPresent()) {
-        final BallotManifestInfo bmi = bmiMaybe.get();
-        // theoretically we don't need cvrs to render ballot info - practically,
-        // though, we need the cvr info for the app to work
-        cvr = queryCVR.apply(bmi.countyID(),
-                             bmi.scannerID(),
-                             bmi.batchID(),
-                             bmi.ballotPosition(rand));
-        if (cvr == null) {
-          // TODO: create a discrepancy when this happens
-          cvr = phantomRecord();
-        }
-        responses.add(toResponse(audit_sequence_number, rand, bmi, cvr));
-      } else {
-        final String msg = "could not find a ballot manifest for random number: "
-            + rand;
-        throw new BallotSelection.MissingBallotManifestException(msg);
-      }
-
-      audit_sequence_number++;
-    }
-    return responses;
-  }
-
   /** select CVRs from random numbers through ballot manifest info
       in "audit sequence order"
    **/
-  public static List<CastVoteRecord> selectCVRs(final List<Long> rands, final Long countyId) {
+  public static List<CastVoteRecord> selectCVRs(final List<Integer> rands,
+                                                final Long countyId) {
     return selectCVRs(rands,
                       countyId,
                       BallotManifestInfoQueries::holdingSequenceNumber,
@@ -93,12 +29,13 @@ public final class BallotSelection {
   }
 
   /** same as above with dependency injection **/
-  public static List<CastVoteRecord> selectCVRs(final List<Long> rands,
+  public static List<CastVoteRecord> selectCVRs(final List<Integer> rands,
                                                 final Long countyId,
                                                 final BMIQ queryBMI,
                                                 final CVRQ queryCVR) {
     final List<CastVoteRecord> cvrs = new LinkedList<CastVoteRecord>();
-    for (final Long rand: rands) {
+    for (final Integer r: rands) {
+      final Long rand = Long.valueOf(r);
       // could we get them all at once? I'm not sure
       final Optional<BallotManifestInfo> bmiMaybe = queryBMI.apply(rand, countyId);
       if (!bmiMaybe.isPresent()) {
@@ -121,18 +58,6 @@ public final class BallotSelection {
     return cvrs;
   }
 
-  /** sort without mutation **/
-  public static List<CVRToAuditResponse> sort(final List<CVRToAuditResponse> cars) {
-    final List<CVRToAuditResponse> clone = new LinkedList<CVRToAuditResponse>(cars);
-    clone.sort(new BallotOrderComparator());
-    return clone;
-  }
-
-  /** remove duplicates **/
-  public static List<CVRToAuditResponse> dedup(final List<CVRToAuditResponse> cars) {
-    return new LinkedList<CVRToAuditResponse>(new LinkedHashSet<CVRToAuditResponse>(cars));
-  }
-
   /** PHANTOM_RECORD conspiracy theory time **/
   public static CastVoteRecord phantomRecord() {
     final CastVoteRecord cvr = new CastVoteRecord(CastVoteRecord.RecordType.PHANTOM_RECORD,
@@ -151,27 +76,7 @@ public final class BallotSelection {
     return cvr;
   }
 
-  /**
-   * get ready to render the data
-   **/
-  public static CVRToAuditResponse toResponse(final int audit_sequence_number,
-                                              final Long rand,
-                                              final BallotManifestInfo bmi,
-                                              final CastVoteRecord cvr) {
-
-    return new CVRToAuditResponse(audit_sequence_number,
-                                  bmi.scannerID(),
-                                  bmi.batchID(),
-                                  bmi.ballotPosition(rand).intValue(),
-                                  bmi.imprintedID(rand),
-                                  cvr.cvrNumber(),
-                                  cvr.id(),
-                                  cvr.ballotType(),
-                                  bmi.storageLocation(),
-                                  cvr.auditFlag());
-  }
-
-  /**
+ /**
    * this is bad, it could be one of two things:
    * - a random number was generated outside of the number of (theoretical) ballots
    * - there is a gap in the sequence_start and sequence_end values of the

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -1,0 +1,210 @@
+/**
+ * Prepare a list of ballots from a list of random numbers
+ **/
+package us.freeandfair.corla.controller;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+import us.freeandfair.corla.json.CVRToAuditResponse;
+import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
+import us.freeandfair.corla.model.BallotManifestInfo;
+import us.freeandfair.corla.model.CastVoteRecord;
+import us.freeandfair.corla.query.BallotManifestInfoQueries;
+import us.freeandfair.corla.query.CastVoteRecordQueries;
+
+public final class BallotSelection {
+
+  /** prevent construction **/
+  private BallotSelection() {
+  }
+
+  /**
+   * Prepare a list of ballots from random numbers. Asks the
+   * ballot_manifest_info table for info and joins in some info from
+   * cast_vote_records. We are very intentional about the source of data coming
+   * from the ballot_manifest_info and not the cast_vote_records. The
+   * cast_vote_records info is merged in as a convenience to find discrepancies
+   * as early as possible.
+   **/
+  public static List<CVRToAuditResponse> selectBallots(final List<Long> rands,
+                                                       final Long countyID) {
+    return selectBallots(rands,
+                         countyID,
+                         BallotManifestInfoQueries::holdingSequenceNumber,
+                         CastVoteRecordQueries::atPosition);
+  }
+
+  /**
+   * same as above with optional dependency injection
+   **/
+  public static List<CVRToAuditResponse>
+      selectBallots(final List<Long> rands,
+                    final Long countyID,
+                    final BMIQ queryBMI,
+                    final CVRQ queryCVR) {
+
+    // this is what gets added to and returned
+    final List<CVRToAuditResponse> responses = new LinkedList<CVRToAuditResponse>();
+
+    Integer audit_sequence_number = 0;
+    for (final Long rand: rands) {
+      // could we get them all at once? I'm not sure
+      final Optional<BallotManifestInfo> bmiMaybe = queryBMI.apply(rand,countyID);
+      CastVoteRecord cvr;
+
+      if (bmiMaybe.isPresent()) {
+        final BallotManifestInfo bmi = bmiMaybe.get();
+        // theoretically we don't need cvrs to render ballot info - practically,
+        // though, we need the cvr info for the app to work
+        cvr = queryCVR.apply(bmi.countyID(),
+                             bmi.scannerID(),
+                             bmi.batchID(),
+                             bmi.ballotPosition(rand));
+        if (cvr == null) {
+          // TODO: create a discrepancy when this happens
+          cvr = phantomRecord();
+        }
+        responses.add(toResponse(audit_sequence_number, rand, bmi, cvr));
+      } else {
+        final String msg = "could not find a ballot manifest for random number: "
+            + rand;
+        throw new BallotSelection.MissingBallotManifestException(msg);
+      }
+
+      audit_sequence_number++;
+    }
+    return responses;
+  }
+
+  /** select CVRs from random numbers through ballot manifest info
+      in "audit sequence order"
+   **/
+  public static List<CastVoteRecord> selectCVRs(final List<Long> rands, final Long countyId) {
+    return selectCVRs(rands,
+                      countyId,
+                      BallotManifestInfoQueries::holdingSequenceNumber,
+                      CastVoteRecordQueries::atPosition);
+  }
+
+  /** same as above with dependency injection **/
+  public static List<CastVoteRecord> selectCVRs(final List<Long> rands,
+                                                final Long countyId,
+                                                final BMIQ queryBMI,
+                                                final CVRQ queryCVR) {
+    final List<CastVoteRecord> cvrs = new LinkedList<CastVoteRecord>();
+    for (final Long rand: rands) {
+      // could we get them all at once? I'm not sure
+      final Optional<BallotManifestInfo> bmiMaybe = queryBMI.apply(rand, countyId);
+      if (!bmiMaybe.isPresent()) {
+        final String msg = "could not find a ballot manifest for random number: "
+            + rand;
+        throw new BallotSelection.MissingBallotManifestException(msg);
+      }
+      final BallotManifestInfo bmi = bmiMaybe.get();
+      CastVoteRecord cvr = queryCVR.apply(bmi.countyID(),
+                                          bmi.scannerID(),
+                                          bmi.batchID(),
+                                          bmi.ballotPosition(rand));
+      if (cvr == null) {
+        // TODO: create a discrepancy when this happens
+        cvr = phantomRecord();
+      }
+
+      cvrs.add(cvr);
+    }
+    return cvrs;
+  }
+
+  /** sort without mutation **/
+  public static List<CVRToAuditResponse> sort(final List<CVRToAuditResponse> cars) {
+    final List<CVRToAuditResponse> clone = new LinkedList<CVRToAuditResponse>(cars);
+    clone.sort(new BallotOrderComparator());
+    return clone;
+  }
+
+  /** remove duplicates **/
+  public static List<CVRToAuditResponse> dedup(final List<CVRToAuditResponse> cars) {
+    return new LinkedList<CVRToAuditResponse>(new LinkedHashSet<CVRToAuditResponse>(cars));
+  }
+
+  /** PHANTOM_RECORD conspiracy theory time **/
+  public static CastVoteRecord phantomRecord() {
+    final CastVoteRecord cvr = new CastVoteRecord(CastVoteRecord.RecordType.PHANTOM_RECORD,
+                                                  null,
+                                                  0L,
+                                                  0,
+                                                  0,
+                                                  0,
+                                                  "",
+                                                  0,
+                                                  "",
+                                                  "PHANTOM RECORD",
+                                                  null);
+    // TODO prevent the client from requesting info about this cvr
+    cvr.setID(0L);
+    return cvr;
+  }
+
+  /**
+   * get ready to render the data
+   **/
+  public static CVRToAuditResponse toResponse(final int audit_sequence_number,
+                                              final Long rand,
+                                              final BallotManifestInfo bmi,
+                                              final CastVoteRecord cvr) {
+
+    return new CVRToAuditResponse(audit_sequence_number,
+                                  bmi.scannerID(),
+                                  bmi.batchID(),
+                                  bmi.ballotPosition(rand).intValue(),
+                                  bmi.imprintedID(rand),
+                                  cvr.cvrNumber(),
+                                  cvr.id(),
+                                  cvr.ballotType(),
+                                  bmi.storageLocation(),
+                                  cvr.auditFlag());
+  }
+
+  /**
+   * this is bad, it could be one of two things:
+   * - a random number was generated outside of the number of (theoretical) ballots
+   * - there is a gap in the sequence_start and sequence_end values of the
+   *   ballot_manifest_infos
+   **/
+  public static class MissingBallotManifestException extends RuntimeException {
+    /** constructor **/
+    public MissingBallotManifestException(final String msg) {
+      super(msg);
+    }
+  }
+
+ /**
+   * a functional interface to pass a function as an argument that takes two
+   * arguments
+   **/
+  public interface CVRQ {
+
+    /** how to query the database **/
+    CastVoteRecord apply(Long county_id,
+                         Integer scanner_id,
+                         String batch_id,
+                         Long position);
+  }
+
+  /**
+   * a functional interface to pass a function as an argument that takes two
+   * arguments
+   **/
+  public interface BMIQ {
+
+    /** how to query the database **/
+    Optional<BallotManifestInfo> apply(Long rand,
+                                       Long countyId);
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -42,6 +42,7 @@ import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.model.DoSDashboard;
 import us.freeandfair.corla.model.Round;
 import us.freeandfair.corla.persistence.Persistence;
+import us.freeandfair.corla.query.BallotManifestInfoQueries;
 import us.freeandfair.corla.query.CastVoteRecordQueries;
 import us.freeandfair.corla.query.CountyContestResultQueries;
 
@@ -76,7 +77,7 @@ public final class ComparisonAuditController {
                                                            final int the_min_index,
                                                            final int the_max_index) {
     final OptionalLong count =
-        CastVoteRecordQueries.countMatching(the_county.id(), RecordType.UPLOADED);
+        BallotManifestInfoQueries.maxSequence(the_county.id());
 
     if (!count.isPresent()) {
       throw new IllegalStateException("unable to count CVRs for county " + the_county.id());
@@ -109,15 +110,8 @@ public final class ComparisonAuditController {
   public static List<CastVoteRecord>
       getCVRsForSequenceNumbers(final County the_county,
                                 final List<Integer> the_seq_num_list) {
-    final Map<Integer, CastVoteRecord> matching_cvrs =
-        CastVoteRecordQueries.get(the_county.id(), RecordType.UPLOADED, the_seq_num_list);
-    final List<CastVoteRecord> result = new ArrayList<>();
-
-    for (final int index : the_seq_num_list) {
-      result.add(matching_cvrs.get(index));
-    }
-
-    return result;
+    return BallotSelection.selectCVRs(the_seq_num_list,
+                                      the_county.id());
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
@@ -35,6 +35,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.controller.BallotSelection;
 import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.json.CVRToAuditResponse;
 import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
@@ -42,7 +43,6 @@ import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.persistence.Persistence;
-import us.freeandfair.corla.query.BallotManifestInfoQueries;
 import us.freeandfair.corla.util.SparkHelper;
 
 /**
@@ -235,16 +235,7 @@ public class CVRToAuditDownload extends AbstractEndpoint {
                                                          duplicates, audited);
       }
      
-      for (int i = 0; i < cvr_to_audit_list.size(); i++) {
-        final CastVoteRecord cvr = cvr_to_audit_list.get(i);
-        final String location = BallotManifestInfoQueries.locationFor(cvr);
-        response_list.add(new CVRToAuditResponse(i, cvr.scannerID(), 
-                                                 cvr.batchID(), cvr.recordID(), 
-                                                 cvr.imprintedID(), 
-                                                 cvr.cvrNumber(), cvr.id(),
-                                                 cvr.ballotType(), location,
-                                                 cvr.auditFlag()));
-      }
+      response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
       response_list.sort(new BallotOrderComparator());
       
       // generate a CSV file from the response list

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -21,6 +21,7 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
+import us.freeandfair.corla.controller.BallotSelection;
 import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.json.CVRToAuditResponse;
 import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
@@ -28,7 +29,6 @@ import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.persistence.Persistence;
-import us.freeandfair.corla.query.BallotManifestInfoQueries;
 
 /**
  * The CVR to audit list endpoint.
@@ -211,16 +211,7 @@ public class CVRToAuditList extends AbstractEndpoint {
                                                          duplicates, audited);
       }
 
-      for (int i = 0; i < cvr_to_audit_list.size(); i++) {
-        final CastVoteRecord cvr = cvr_to_audit_list.get(i);
-        final String location = BallotManifestInfoQueries.locationFor(cvr);
-        response_list.add(new CVRToAuditResponse(i, cvr.scannerID(),
-                                                 cvr.batchID(), cvr.recordID(),
-                                                 cvr.imprintedID(),
-                                                 cvr.cvrNumber(), cvr.id(),
-                                                 cvr.ballotType(), location,
-                                                 cvr.auditFlag()));
-      }
+      response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
       response_list.sort(new BallotOrderComparator());
       okJSON(the_response, Main.GSON.toJson(response_list));
     } catch (final PersistenceException e) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
@@ -219,7 +219,8 @@ public class BallotManifestInfo implements PersistentEntity, Serializable {
   }
 
   /**
-   * computed value based on other values
+   * computed value based on scannerId,batchID, and ballotPosition (in the bin)
+   * This is what the auditors will use to confirm they have the correct card.
    **/
   public String imprintedID(final Long rand) {
     return scannerID() + "-" +
@@ -228,7 +229,7 @@ public class BallotManifestInfo implements PersistentEntity, Serializable {
   }
 
   /**
-   * computed value based on other values
+   * where the ballot sits in it's storage bin
    **/
   public Long ballotPosition(final Long rand) {
     // position is the nth (1 based)

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/BallotManifestInfo.java
@@ -219,6 +219,23 @@ public class BallotManifestInfo implements PersistentEntity, Serializable {
   }
 
   /**
+   * computed value based on other values
+   **/
+  public String imprintedID(final Long rand) {
+    return scannerID() + "-" +
+           batchID() + "-" +
+           ballotPosition(rand).toString();
+  }
+
+  /**
+   * computed value based on other values
+   **/
+  public Long ballotPosition(final Long rand) {
+    // position is the nth (1 based)
+    return rand - sequenceStart() + 1L;
+  }
+
+  /**
    * @return a String representation of this object.
    */
   @Override

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
@@ -195,7 +195,7 @@ public final class BallotManifestInfoQueries {
   /**
    * Get the max sequence number which is the total number of CVRs there should be
    */
-  public static OptionalLong maxSequence(final Long the_county) {
+  public static OptionalLong maxSequence(final Long countyId) {
     OptionalLong result = OptionalLong.empty();
 
     try {
@@ -204,7 +204,7 @@ public final class BallotManifestInfoQueries {
       final CriteriaQuery<Long> cq = cb.createQuery(Long.class);
       final Root<BallotManifestInfo> root = cq.from(BallotManifestInfo.class);
       cq.select(cb.max(root.get("my_sequence_end")));
-      cq.where(cb.equal(root.get(COUNTY_ID), the_county));
+      cq.where(cb.equal(root.get(COUNTY_ID), countyId));
 
       final TypedQuery<Long> query = s.createQuery(cq);
       result = OptionalLong.of(query.getSingleResult());

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/BallotManifestInfoQueries.java
@@ -92,24 +92,23 @@ public final class BallotManifestInfoQueries {
    * @param the_cvr The CVR.
    * @return the location for the CVR, or null if no location can be found.
    */
-  public static String locationFor(final CastVoteRecord the_cvr) {
-    String result = null;
+  public static Optional<BallotManifestInfo> locationFor(final CastVoteRecord the_cvr) {
+    Optional<BallotManifestInfo> result = Optional.empty();
 
     try {
       final Session s = Persistence.currentSession();
       final CriteriaBuilder cb = s.getCriteriaBuilder();
-      final CriteriaQuery<String> cq = cb.createQuery(String.class);
+      final CriteriaQuery<BallotManifestInfo> cq = cb.createQuery(BallotManifestInfo.class);
       final Root<BallotManifestInfo> root = cq.from(BallotManifestInfo.class);
-      cq.select(root.get("my_storage_location"));
       cq.where(cb.and(cb.equal(root.get("my_county_id"), the_cvr.countyID()),
                       cb.equal(root.get("my_scanner_id"), the_cvr.scannerID()),
                       cb.equal(root.get("my_batch_id"), the_cvr.batchID())));
-      final TypedQuery<String> query = s.createQuery(cq);
-      final List<String> query_result = query.getResultList();
+      final TypedQuery<BallotManifestInfo> query = s.createQuery(cq);
+      final List<BallotManifestInfo> query_result = query.getResultList();
       // there should never be more than one result, but if there is, we'll
       // return the first one
       if (!query_result.isEmpty()) {
-        result = query_result.get(0);
+        result = Optional.of(query_result.get(0));
       }
     } catch (final PersistenceException e) {
       Main.LOGGER.error("Exception when finding ballot location: " + e);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
@@ -368,4 +368,39 @@ public final class CastVoteRecordQueries {
 
     return result;
   }
+
+  /**
+   * join query
+   **/
+  public static CastVoteRecord atPosition(final Long county_id,
+                                          final Integer scanner_id,
+                                          final String batch_id,
+                                          final Long position) {
+    List<CastVoteRecord> result = null;
+
+    try {
+      final Session s = Persistence.currentSession();
+      final CriteriaBuilder cb = s.getCriteriaBuilder();
+      final CriteriaQuery<CastVoteRecord> cq = cb.createQuery(CastVoteRecord.class);
+      final Root<CastVoteRecord> root = cq.from(CastVoteRecord.class);
+      cq.select(root).where(cb.and(cb.equal(root.get("my_county_id"), county_id),
+                                   cb.equal(root.get("my_scanner_id"), scanner_id),
+                                   cb.equal(root.get("my_batch_id"), batch_id),
+                                   cb.equal(root.get("my_record_id"), position)));
+      final TypedQuery<CastVoteRecord> query = s.createQuery(cq);
+      result = query.getResultList();
+    } catch (final PersistenceException e) {
+      Main.LOGGER.error(COULD_NOT_QUERY_DATABASE);
+    }
+
+    switch (result.size()) {
+      case 1:
+        return result.get(0);
+      case 0:
+        return null;
+      default:
+        Main.LOGGER.error("found more than one cvr atPosition: \n" + result);
+        return result.get(0);
+    }
+  }
 }

--- a/server/eclipse-project/src/main/resources/log4j.properties
+++ b/server/eclipse-project/src/main/resources/log4j.properties
@@ -10,3 +10,6 @@ log4j.appender.logfile=org.apache.log4j.RollingFileAppender
 log4j.appender.logfile.File=corla.log
 log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
 log4j.appender.logfile.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+
+
+log4j.logger.org.hibernate.SQL=ERROR

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
@@ -1,7 +1,6 @@
 package us.freeandfair.corla.controllers;
 
 import us.freeandfair.corla.controller.BallotSelection;
-import us.freeandfair.corla.json.CVRToAuditResponse;
 import us.freeandfair.corla.model.BallotManifestInfo;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.persistence.Persistence;
@@ -16,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.testng.annotations.Test;
 import org.testng.Assert;
@@ -31,18 +31,18 @@ public class BallotSelectionTest {
   public void testSelectBallotsReturnsListOfOnes(){
     Long rand = 1L;
     Long sequence_start = 1L;
-    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    List<CastVoteRecord> results = makeSelection(rand,sequence_start);
     Assert.assertEquals(1, results.size());
-    Assert.assertEquals(results.get(0).imprintedID(), "1-1-1");
+    Assert.assertEquals(results.get(0).imprintedID(), "1-Batch1-1");
   }
 
   @Test()
   public void testSelectBallotsReturnsListHappyPath(){
     Long rand = 47L;
     Long sequence_start = 41L;
-    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    List<CastVoteRecord> results = makeSelection(rand,sequence_start);
     Assert.assertEquals(1, results.size());
-    Assert.assertEquals(results.get(0).imprintedID(), "1-1-7");
+    Assert.assertEquals(results.get(0).imprintedID(), "1-Batch1-1");
   }
 
   @Test()
@@ -51,14 +51,14 @@ public class BallotSelectionTest {
     Long sequence_start = 41L;
     // overwrite var
     return_cvr = false;
-    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    List<CastVoteRecord> results = makeSelection(rand,sequence_start);
     Assert.assertEquals(1, results.size());
-    Assert.assertEquals(results.get(0).imprintedID(), "1-1-7");
+    Assert.assertEquals(results.get(0).imprintedID(), "");
     Assert.assertEquals(results.get(0).ballotType(), "PHANTOM RECORD");
-    Assert.assertEquals(results.get(0).cvrNumber(), 0);
+    Assert.assertEquals((int)results.get(0).cvrNumber(), (int)0);
   }
 
-  private List<CVRToAuditResponse> makeSelection(Long rand, Long sequence_start) {
+  private List<CastVoteRecord> makeSelection(Long rand, Long sequence_start) {
     // setup
     Long sequence_end = rand - sequence_start + 1L;
     List<Long> rands = new ArrayList<Long>();
@@ -70,9 +70,10 @@ public class BallotSelectionTest {
                                      Integer scanner_id,
                                      String batch_id,
                                      Long position) -> fakeCVR();
+    List<Integer> lols = rands.stream().map(l -> (int)l.intValue()).collect(Collectors.toList());
 
     // subject under test
-    return BallotSelection.selectBallots(rands, 0L, query, queryCVR);
+    return BallotSelection.selectCVRs(lols, 0L, query, queryCVR);
   }
 
   public CastVoteRecord fakeCVR() {

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
@@ -1,0 +1,112 @@
+package us.freeandfair.corla.controllers;
+
+import us.freeandfair.corla.controller.BallotSelection;
+import us.freeandfair.corla.json.CVRToAuditResponse;
+import us.freeandfair.corla.model.BallotManifestInfo;
+import us.freeandfair.corla.model.CastVoteRecord;
+import us.freeandfair.corla.persistence.Persistence;
+
+import java.time.Instant;
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class BallotSelectionTest {
+
+
+  private BallotSelectionTest (){};
+
+  private Boolean return_cvr = true;
+
+  @Test()
+  public void testSelectBallotsReturnsListOfOnes(){
+    Long rand = 1L;
+    Long sequence_start = 1L;
+    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(results.get(0).imprintedID(), "1-1-1");
+  }
+
+  @Test()
+  public void testSelectBallotsReturnsListHappyPath(){
+    Long rand = 47L;
+    Long sequence_start = 41L;
+    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(results.get(0).imprintedID(), "1-1-7");
+  }
+
+  @Test()
+  public void testSelectBallotsReturnsPhantomRecord(){
+    Long rand = 47L;
+    Long sequence_start = 41L;
+    // overwrite var
+    return_cvr = false;
+    List<CVRToAuditResponse> results = makeSelection(rand,sequence_start);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(results.get(0).imprintedID(), "1-1-7");
+    Assert.assertEquals(results.get(0).ballotType(), "PHANTOM RECORD");
+    Assert.assertEquals(results.get(0).cvrNumber(), 0);
+  }
+
+  private List<CVRToAuditResponse> makeSelection(Long rand, Long sequence_start) {
+    // setup
+    Long sequence_end = rand - sequence_start + 1L;
+    List<Long> rands = new ArrayList<Long>();
+    rands.add(rand);
+
+    BallotManifestInfo bmi = fakeBMI(sequence_start, sequence_end);
+    BallotSelection.BMIQ query = (Long r, Long c) -> Optional.of(bmi);
+    BallotSelection.CVRQ queryCVR = (Long county_id,
+                                     Integer scanner_id,
+                                     String batch_id,
+                                     Long position) -> fakeCVR();
+
+    // subject under test
+    return BallotSelection.selectBallots(rands, 0L, query, queryCVR);
+  }
+
+  public CastVoteRecord fakeCVR() {
+    if (return_cvr) {
+      Instant now = Instant.now();
+      CastVoteRecord cvr = new CastVoteRecord(CastVoteRecord.RecordType.UPLOADED,
+                                              now,
+                                              64L,          // county_id
+                                              1,            // cvr_number
+                                              1,            // sequence_number
+                                              1,            // scanner_id
+                                              "Batch1",     // batch_id
+                                              1,            // record_id
+                                              "1-Batch1-1", // imprinted_id
+                                              "paper",      // ballot_type
+                                              null          // contest_info
+                                              );
+
+      cvr.setID(1L);
+      return cvr;
+    } else {
+      return null;
+    }
+  }
+
+  public BallotManifestInfo fakeBMI(Long sequence_start,Long sequence_end){
+    BallotManifestInfo bmi = new BallotManifestInfo(1L,             // county_id
+                                                    1,              // scanner_id
+                                                    "1",            // batch_id
+                                                    1,              // batch_size
+                                                    "bin-1",        // storage_location
+                                                    sequence_start, // sequence_start
+                                                    sequence_end    // sequence_end
+                                                    );
+    return bmi;
+  }
+}

--- a/test/smoketest/main.py
+++ b/test/smoketest/main.py
@@ -182,11 +182,14 @@ parser.add_argument('-C, --contest', dest='contests', metavar='CONTEST', action=
                     '-1 means "audit all contests')
 parser.add_argument('-l, --loser', dest='loser', default="UNDERVOTE",
                     help='Loser to use for -p, default "UNDERVOTE"')
-parser.add_argument('-p, --discrepancy-plan', dest='plan', default="2 17",
-                    help='Planned discrepancies. Default is "2 17", i.e. '
+parser.add_argument('-p, --discrepancy-plan', dest='plan', default="5 17",
+                    help='Planned discrepancies. Default is "5 17", i.e. '
                     'Every 17 ACVR uploads, upload a possible discrepancy once, '
                     'when the remainder of dividing the upload index is 2. '
-                    'Discrepancies thus come with the 3rd of every 17 ACVR uploads.')
+                    'Discrepancies thus come with the 3rd of every 17 ACVR uploads.'
+                    'This default is designed to hit a known ballot and to trigger a second round.'
+                    'You will see different audits happen from different discrepancies happening '
+                    '(or not happening) on different ballots.')
 parser.add_argument('-P, --discrepancy-end', dest='plan_limit', type=int, default=sys.maxint,
                     help='Last upload with possible discrepancy is # PLAN_LIMIT')
 


### PR DESCRIPTION
This change makes random selection based on the manifest instead of the CVR data. Rendered data from the selections is also from the manifest(mostly). There is a bunch of CVR stuff in the middle, but I think this will satisfy the requirement of not using CVR data to choose ballots.