### PR TITLE
Show the risk limit with two digits of precision

### DIFF
--- a/client/src/component/DOS/DefineAudit/ReviewPage.tsx
+++ b/client/src/component/DOS/DefineAudit/ReviewPage.tsx
@@ -85,6 +85,10 @@ interface AuditReviewProps {
     dosState: DOS.AppState;
 }
 
+function riskLimitPercent(dosState: DOS.AppState) {
+    return (dosState.riskLimit! * 100).toFixed(2);
+}
+
 const AuditReview = (props: AuditReviewProps) => {
     const { back, publishBallotsToAudit, saveAndDone, dosState } = props;
 
@@ -92,8 +96,6 @@ const AuditReview = (props: AuditReviewProps) => {
         publishBallotsToAudit();
         saveAndDone();
     };
-
-    const riskLimitPercent = dosState.riskLimit! * 100;
 
     const disableLaunchButton = !dosState.seed;
 
@@ -126,7 +128,7 @@ const AuditReview = (props: AuditReviewProps) => {
                         </tr>
                         <tr>
                             <td>Risk Limit:</td>
-                            <td>{ riskLimitPercent }%</td>
+                            <td>{ riskLimitPercent(dosState) }%</td>
                         </tr>
                         <tr>
                             <td>Random Number Generator Seed:</td>


### PR DESCRIPTION
From my browser's console:

![javascript math](https://user-images.githubusercontent.com/104658/43657447-20d1b6c2-9713-11e8-8b5a-b36c783bf839.png)

We get a string rather than a number, which is perfect for being in a template.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed#Description

[🐛 in Tracker](https://www.pivotaltracker.com/story/show/159416669)