### PR TITLE
Improve Docker build process primarily for the server component

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,19 +78,10 @@ this, you most likely want to install test credentials, which are already inside
 the PostgreSQL image:
 
 ```sh
-docker exec -i coloradorla_postgresql_1 \
+docker-compose exec postgresql \
   /bin/bash -c \
   'psql -U corla -d corla < /root/corla-test-credentials.psql'
 ```
-
-Note that `coloradorla_postgresql_1` is the output of "Name" from
-
-```sh
-docker-compose ps postgresql
-```
-
-but should be consistent assuming you have checked out the code to a directory
-named the same as the repository.
 
 # Installation and Use
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build:
       context: .
       dockerfile: ./docker/server/Dockerfile
-      args:
-        - VERSION=1.4.0-SNAPSHOT
     depends_on:
       - postgresql
     ports:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,7 +12,10 @@ SERVER_TAG ?= latest
 .PHONY: httpd-build httpd-deploy
 
 httpd-build:
-	docker build -f httpd/Dockerfile -t $(HTTPD_REPOSITORY):$(HTTPD_TAG) ../
+	docker build \
+		-f httpd/Dockerfile \
+		-t $(HTTPD_REPOSITORY):$(HTTPD_TAG) \
+		../
 
 httpd-deploy:
 	docker push $(HTTPD_REPOSITORY):$(HTTPD_TAG)
@@ -22,7 +25,10 @@ httpd-deploy:
 .PHONY: postgresql-build postgresql-deploy
 
 postgresql-build:
-	docker build -f postgresql/Dockerfile -t $(POSTGRESQL_REPOSITORY):$(POSTGRESQL_TAG) ../
+	docker build \
+		-f postgresql/Dockerfile \
+		-t $(POSTGRESQL_REPOSITORY):$(POSTGRESQL_TAG) \
+		../
 
 postgresql-deploy:
 	docker push $(POSTGRESQL_REPOSITORY):$(POSTGRESQL_TAG)
@@ -32,8 +38,9 @@ postgresql-deploy:
 .PHONY: server-build server-deploy
 
 server-build:
-	docker build -f server/Dockerfile -t $(SERVER_REPOSITORY):$(SERVER_TAG) \
-		--build-arg VERSION=$(shell cd ../server/eclipse-project; mvn help:evaluate -Dexpression=project.version | grep '^[[:digit:]].\+') \
+	docker build \
+		-f server/Dockerfile \
+		-t $(SERVER_REPOSITORY):$(SERVER_TAG) \
 		../
 
 server-deploy:

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,17 +1,19 @@
 FROM maven:3 as maven
 
 COPY server/eclipse-project /srv/corla/server/eclipse-project
-RUN cd /srv/corla/server/eclipse-project && mvn package
+
+WORKDIR /srv/corla/server/eclipse-project
+
+RUN mvn clean
+RUN mvn package
 
 FROM openjdk:8
 LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
 
-ARG VERSION
-
 ## TODO: How can we architect this such that passing -Dthe.prop=value works as
 ## expected?
 COPY docker/server/docker.properties /srv/corla/docker.properties
-COPY --from=maven /srv/corla/server/eclipse-project/target/colorado_rla-${VERSION}-shaded.jar \
+COPY --from=maven /srv/corla/server/eclipse-project/target/colorado_rla-*-shaded.jar \
      /srv/corla/corla.jar
 
 CMD ["java", \


### PR DESCRIPTION
The main benefit of this change is no longer having to specify the version number in `docker-compose.yml`.