### PR TITLE
Fix a bug where standardized contests would sometimes not display on first run

### DIFF
--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
@@ -69,37 +69,21 @@ interface ContainerProps {
     dosState: DOS.AppState;
 }
 
+/**
+ * The URL path part for the page logically following this one.
+ */
+const NEXT_PAGE = '/sos/audit/select-contests';
+
+/**
+ * The URL path part for the page logically preceding this one.
+ */
+const PREVIOUS_PAGE = '/sos/audit';
+
 class StandardizeContestsPageContainer extends React.Component<ContainerProps> {
-    private areContestsLoaded: boolean;
-    private areCanonicalContestsLoaded: boolean;
     private forms: DOS.Form.StandardizeContests.Ref;
-    private nextPage: string;
-    private previousPage: string;
-
-    // XXX: This is *really bad* React. I know, and I'm sorry about it.
-    public constructor(props: ContainerProps) {
-        super(props);
-
-        this.nextPage = '/sos/audit/select-contests';
-        this.previousPage = '/sos/audit';
-    }
 
     public componentDidMount() {
-        this.areContestsLoaded = false;
-        this.areCanonicalContestsLoaded = false;
         this.forms = { standardizeContestsForm: {} };
-    }
-
-    // XXX: Hack to work around waiting on a network to receive these new
-    // props.
-    public componentDidUpdate(prevProps: ContainerProps) {
-        if (this.props.contests !== prevProps.contests) {
-            this.areContestsLoaded = true;
-        }
-
-        if (this.props.canonicalContests !== prevProps.canonicalContests) {
-            this.areCanonicalContestsLoaded = true;
-        }
     }
 
     public render() {
@@ -114,9 +98,9 @@ class StandardizeContestsPageContainer extends React.Component<ContainerProps> {
             return <div />;
         }
 
-        const previousPage = () => history.push(this.previousPage);
+        const previousPage = () => history.push(PREVIOUS_PAGE);
 
-        if (!this.areContestsLoaded || !this.areCanonicalContestsLoaded) {
+        if (_.isEmpty(contests) || _.isEmpty(canonicalContests)) {
             return <WaitingForContests back={ previousPage } />;
         }
 
@@ -127,7 +111,7 @@ class StandardizeContestsPageContainer extends React.Component<ContainerProps> {
         const filteredContests = contestsToDisplay(contests, canonicalContests);
 
         if (_.isEmpty(filteredContests)) {
-            return <Redirect to={ this.nextPage } />;
+            return <Redirect to={ NEXT_PAGE } />;
         }
 
         const props = {
@@ -139,7 +123,7 @@ class StandardizeContestsPageContainer extends React.Component<ContainerProps> {
             forms: this.forms,
             nextPage: () => {
                 standardizeContests(this.forms.standardizeContestsForm || {});
-                history.push(this.nextPage);
+                history.push(NEXT_PAGE);
             },
         };
 

--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
@@ -21,21 +21,21 @@ import counties from 'corla/data/counties';
 
 const contestsToDisplay = (contests: DOS.Contests,
                            canonicalContests: DOS.CanonicalContests) => {
-    const cs: DOS.Contests = {};
+    const displayedContests: DOS.Contests = {};
 
     // XXX: Make this a map / filter chain. TypeScript complains about using
     // `DOS.Contests` in a `_.filter` context, and I do not know how to make it
     // happy.
-    _.forEach(contests, (c: Contest) => {
-        const countyName = counties[c.countyId].name;
+    _.forEach(contests, (contest: Contest) => {
+        const countyName = counties[contest.countyId].name;
         const countyStandards = canonicalContests[countyName] || [];
 
-        if (!_.isEmpty(countyStandards) && !_.includes(countyStandards, c.name)) {
-          cs[c.id] = c;
+        if (!_.isEmpty(countyStandards) && !_.includes(countyStandards, contest.name)) {
+          displayedContests[contest.id] = contest;
         }
     });
 
-    return cs;
+    return displayedContests;
 };
 
 interface WaitingForContestsProps {


### PR DESCRIPTION
This fixes a small-ish bug I noticed when running through the audit definition process a few times in a few different ways. When uploading large standardized contest name files, timing issues could cause our standardization logic to think there were no canonical contest names uploaded and thus skip the step. This would usually happen only on the first run through the audit definition workflow, but the first run through is also the most important.

The current architecture of the audit definition workflow is highly asynchronous, to the point that we render the standardized contests page before the file upload is even complete. If no data is present in the database, it is possible to have renders that change standardized contest props more than two times but without new data, thus fooling the brittle flag-checks we were doing.

When I wrote this, I did not realize that the standardized contest upload was a required step. We can now leverage that knowledge to wait until there is actually data before making a decision as to whether we want to skip the contest standardization step or not, rather than relying on props changing.