### PR TITLE
Always pull new base Docker images when building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The sprint ending on 8/29/2018
 
 - [API - Log on phantom CVR creation][pr33]
 - [UI - Fix a bug where standardized contests would sometimes not display on first run][pr34]
+- [INFRA - Always pull new base Docker images when building][pr35]
 
 ## 1.3.4 - Bugfixes
 
@@ -79,3 +80,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr29]: https://github.com/democracyworks/ColoradoRLA/pull/29
 [pr33]: https://github.com/democracyworks/ColoradoRLA/pull/33
 [pr34]: https://github.com/democracyworks/ColoradoRLA/pull/34
+[pr35]: https://github.com/democracyworks/ColoradoRLA/pull/35

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,7 +12,7 @@ SERVER_TAG ?= latest
 .PHONY: httpd-build httpd-deploy
 
 httpd-build:
-	docker build \
+	docker build --pull \
 		-f httpd/Dockerfile \
 		-t $(HTTPD_REPOSITORY):$(HTTPD_TAG) \
 		../
@@ -25,7 +25,7 @@ httpd-deploy:
 .PHONY: postgresql-build postgresql-deploy
 
 postgresql-build:
-	docker build \
+	docker build --pull \
 		-f postgresql/Dockerfile \
 		-t $(POSTGRESQL_REPOSITORY):$(POSTGRESQL_TAG) \
 		../
@@ -38,7 +38,7 @@ postgresql-deploy:
 .PHONY: server-build server-deploy
 
 server-build:
-	docker build \
+	docker build --pull \
 		-f server/Dockerfile \
 		-t $(SERVER_REPOSITORY):$(SERVER_TAG) \
 		../


### PR DESCRIPTION
We leave some versions unspecified, like requiring Apache `httpd:2.4`, but we want to allow the patch versions to float without having to explicitly touch the Dockerfile. This way we receive security updates as they are released.