### PR TITLE
[test] [fix] Better debugging for smoketest main.py

### DIFF
--- a/test/smoketest/main.py
+++ b/test/smoketest/main.py
@@ -585,7 +585,7 @@ def get_county_dashboard(ac, county_s, county_id, i=0, acvr={'id': -1}, show=Tru
     total_audited = 1 + county_dashboard['audited_ballot_count']
 
     if show:
-        logging.debug("county-dashboard: %s" % r.text)
+        logging.log(5, "county-dashboard: %s" % r.text)
         print("Round %d, county %d, upload %d, prefix %d: aCVR %d; ballots_remaining_in_round: %d, optimistic_ballots_to_audit: %s est %s" %
               (ac.round, county_id, total_audited, county_dashboard.get('audited_prefix_length', -1), acvr['id'],  # FIXME
                county_dashboard['ballots_remaining_in_round'], county_dashboard['optimistic_ballots_to_audit'], county_dashboard['estimated_ballots_to_audit']))
@@ -652,7 +652,7 @@ def dos_start(ac):
     'Run DOS steps to start the audit, enabling county auditing to begin: contest selection, seed, etc.'
 
     if len(ac.audited_contests) <= 0:
-        print("No contests to audit, status_code = %d" % r.status_code)
+        print("No contests to audit. Perhaps CVR or -C option is invalid?")
         return
 
     for contest_id in ac.audited_contests:
@@ -753,13 +753,12 @@ def county_audit(ac, county_id):
             r = test_endpoint_get(ac, county_s, "/audit-board-asm-state")
             # print(r.text)
 
+        total_audited = county_dashboard['audited_ballot_count']
+
         r = test_endpoint_get(ac, county_s, "/cvr/id/%d" % selected[i]['db_id'], show=False)
         acvr = r.json()
-        logging.debug("Original CVR: %s" % json.dumps(acvr))
+        logging.debug("Audited ballot %d original CVR: %s" % (total_audited, json.dumps(acvr)))
         acvr['record_type'] = 'AUDITOR_ENTERED'
-
-        total_audited = county_dashboard['audited_ballot_count']
-        # print("total_audited: %d" % total_audited)
 
         # Modify the aCVR sometimes.
         if (total_audited % ac.discrepancy_cycle == ac.discrepancy_remainder


### PR DESCRIPTION
Fix bug in smoketest/main.py

      File "./main.py", line 655, in dos_start                                                                                          
       print("No contests to audit, status_code = %d" % r.status_code)                                                                 
       UnboundLocalError: local variable 'r' referenced before assignment                                                                  

and log number of audited ballot when printing out ACVRs, for easier comparison
and reduce logging level for very verbose dashboard debugging printouts
