### PR TITLE
Pick and store audit board number

### DIFF
--- a/client/county.d.ts
+++ b/client/county.d.ts
@@ -3,6 +3,7 @@ declare namespace County {
         acvrs: ACVRs;
         asm: ASMStates;
         auditBoard: AuditBoard;
+        auditBoardCount?: number;
         auditedBallotCount?: number;
         ballotManifest?: UploadedFile;
         ballotManifestCount?: number;

--- a/client/json.d.ts
+++ b/client/json.d.ts
@@ -45,6 +45,7 @@ declare namespace JSON {
 
     interface CountyDashboard {
         asm_state: string;
+        audit_board_count?: number;
         audit_board: any;
         audit_info: any;
         audit_time: string;

--- a/client/screen.css
+++ b/client/screen.css
@@ -68,6 +68,10 @@ div{
     margin: 10px;
 }
 
+.pt-button-group.corla-spaced > .pt-button:not(:last-child) {
+  margin-right: 10px;
+}
+
 .pt-table {
     border-spacing: 0;
     font-size: 16px !important;

--- a/client/src/action/county/auditBoardSignIn.ts
+++ b/client/src/action/county/auditBoardSignIn.ts
@@ -16,4 +16,6 @@ const auditBoardSignIn = createSubmitAction({
 });
 
 
-export default (board: AuditBoard) => auditBoardSignIn(format(board));
+export default (index: number, board: AuditBoard) => {
+    auditBoardSignIn(format(index, board));
+}

--- a/client/src/action/county/auditBoardSignIn.ts
+++ b/client/src/action/county/auditBoardSignIn.ts
@@ -18,4 +18,4 @@ const auditBoardSignIn = createSubmitAction({
 
 export default (index: number, board: AuditBoard) => {
     auditBoardSignIn(format(index, board));
-}
+};

--- a/client/src/action/county/setNumberOfAuditBoards.ts
+++ b/client/src/action/county/setNumberOfAuditBoards.ts
@@ -21,4 +21,4 @@ export default (params: SetAuditBoardCountParams) => {
   const req = { count: params.auditBoardCount };
 
   setAuditBoardCount(req);
-}
+};

--- a/client/src/action/county/setNumberOfAuditBoards.ts
+++ b/client/src/action/county/setNumberOfAuditBoards.ts
@@ -1,0 +1,24 @@
+import { endpoint } from 'corla/config';
+
+import createSubmitAction from 'corla/action/createSubmitAction';
+
+
+const url = endpoint('set-audit-board-count');
+
+const setAuditBoardCount = createSubmitAction({
+    failType: 'SET_NUMBER_OF_AUDIT_BOARDS_FAIL',
+    networkFailType: 'SET_NUMBER_OF_AUDIT_BOARDS_NETWORK_FAIL',
+    okType: 'SET_NUMBER_OF_AUDIT_BOARDS_OK',
+    sendType: 'SET_NUMBER_OF_AUDIT_BOARDS_SEND',
+    url,
+});
+
+interface SetAuditBoardCountParams {
+    auditBoardCount: number;
+}
+
+export default (params: SetAuditBoardCountParams) => {
+  const req = { count: params.auditBoardCount };
+
+  setAuditBoardCount(req);
+}

--- a/client/src/adapter/countyDashboardRefresh.ts
+++ b/client/src/adapter/countyDashboardRefresh.ts
@@ -141,6 +141,7 @@ export function parse(data: JSON.CountyDashboard, state: County.AppState) {
 
     return {
         asm_state: data.asm_state,
+        auditBoardCount: data.audit_board_count,
         auditBoard: parseAuditBoard(data.audit_board),
         auditTime: data.audit_time ? parseTimestamp(data.audit_time) : null,
         auditedBallotCount: data.audited_ballot_count,

--- a/client/src/adapter/countyDashboardRefresh.ts
+++ b/client/src/adapter/countyDashboardRefresh.ts
@@ -141,8 +141,8 @@ export function parse(data: JSON.CountyDashboard, state: County.AppState) {
 
     return {
         asm_state: data.asm_state,
-        auditBoardCount: data.audit_board_count,
         auditBoard: parseAuditBoard(data.audit_board),
+        auditBoardCount: data.audit_board_count,
         auditTime: data.audit_time ? parseTimestamp(data.audit_time) : null,
         auditedBallotCount: data.audited_ballot_count,
         auditedPrefixLength: data.audited_prefix_length,

--- a/client/src/adapter/establishBoard.ts
+++ b/client/src/adapter/establishBoard.ts
@@ -9,5 +9,9 @@ const formatBoardMember = (elector: AuditBoardMember): JSON.AuditBoardMember => 
 };
 
 
-export const format = (board: AuditBoard): JSON.AuditBoardMember[] =>
-    board.map(formatBoardMember);
+export const format = (index: number, board: AuditBoard): object => {
+    return {
+        index,
+        audit_board: board.map(formatBoardMember)
+    };
+}

--- a/client/src/adapter/establishBoard.ts
+++ b/client/src/adapter/establishBoard.ts
@@ -11,7 +11,7 @@ const formatBoardMember = (elector: AuditBoardMember): JSON.AuditBoardMember => 
 
 export const format = (index: number, board: AuditBoard): object => {
     return {
+        audit_board: board.map(formatBoardMember),
         index,
-        audit_board: board.map(formatBoardMember)
     };
-}
+};

--- a/client/src/component/County/AuditBoard/Page.tsx
+++ b/client/src/component/County/AuditBoard/Page.tsx
@@ -41,7 +41,8 @@ class AuditBoardSignInPage extends React.Component<PageProps, PageState> {
             return <div />;
         }
 
-        const submit = () => auditBoardSignIn(this.state.form);
+        // TODO: Set the index according to the button clicked...
+        const submit = () => auditBoardSignIn(0, this.state.form);
 
         const disableButton = !isValidAuditBoard(this.state.form);
 

--- a/client/src/component/County/Dashboard/AuditBoardNumberSelector.tsx
+++ b/client/src/component/County/Dashboard/AuditBoardNumberSelector.tsx
@@ -30,42 +30,14 @@ class AuditBoardNumberSelector
 
         this.state = {
           auditBoardCount: props.auditBoardCount,
-          isEnabled: props.isEnabled
+          isEnabled: props.isEnabled,
         };
 
         this.handleChangeAuditBoards = this.handleChangeAuditBoards.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
     }
 
-    handleChangeAuditBoards(asNumber: number, asString: string) {
-        if (asNumber >= 1) {
-          this.setState({ auditBoardCount: asNumber });
-        }
-    }
-
-    handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-        e.preventDefault();
-
-        const { auditBoardCount } = this.state;
-
-        this.setState({ isEnabled: false });
-        setNumberOfAuditBoards({ auditBoardCount });
-    }
-
-    helperText(toAudit?: number) {
-        if (!toAudit) {
-            return null;
-        }
-
-        return (
-            <div className='pt-form-helper-text'>
-                There are <b>{ toAudit }</b>  ballot cards to audit in this
-                round.
-            </div>
-        );
-    }
-
-    render() {
+    public render() {
         const { isShown, numberOfBallotsToAudit } = this.props;
         const { isEnabled } = this.state;
 
@@ -95,6 +67,34 @@ class AuditBoardNumberSelector
             </div>
         );
     }
-};
+
+    private handleChangeAuditBoards(asNumber: number, asString: string) {
+        if (asNumber >= 1) {
+          this.setState({ auditBoardCount: asNumber });
+        }
+    }
+
+    private handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+
+        const { auditBoardCount } = this.state;
+
+        this.setState({ isEnabled: false });
+        setNumberOfAuditBoards({ auditBoardCount });
+    }
+
+    private helperText(toAudit?: number) {
+        if (!toAudit) {
+            return null;
+        }
+
+        return (
+            <div className='pt-form-helper-text'>
+                There are <b>{ toAudit }</b>  ballot cards to audit in this
+                round.
+            </div>
+        );
+    }
+}
 
 export default AuditBoardNumberSelector;

--- a/client/src/component/County/Dashboard/AuditBoardNumberSelector.tsx
+++ b/client/src/component/County/Dashboard/AuditBoardNumberSelector.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+
+import { NumericInput } from '@blueprintjs/core';
+
+import setNumberOfAuditBoards from 'corla/action/county/setNumberOfAuditBoards';
+
+
+/**
+ * Minimum number of audit boards that can participate.
+ */
+const MIN_AUDIT_BOARDS = 1;
+
+interface AuditBoardNumberSelectorProps {
+    auditBoardCount: number;
+    numberOfBallotsToAudit?: number;
+    isShown: boolean;
+    isEnabled: boolean;
+}
+
+interface AuditBoardNumberSelectorState {
+    auditBoardCount: number;
+    isEnabled: boolean;
+}
+
+class AuditBoardNumberSelector
+    extends React.Component<AuditBoardNumberSelectorProps,
+                            AuditBoardNumberSelectorState> {
+    constructor(props: AuditBoardNumberSelectorProps) {
+        super(props);
+
+        this.state = {
+          auditBoardCount: props.auditBoardCount,
+          isEnabled: props.isEnabled
+        };
+
+        this.handleChangeAuditBoards = this.handleChangeAuditBoards.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    handleChangeAuditBoards(asNumber: number, asString: string) {
+        if (asNumber >= 1) {
+          this.setState({ auditBoardCount: asNumber });
+        }
+    }
+
+    handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+
+        const { auditBoardCount } = this.state;
+
+        this.setState({ isEnabled: false });
+        setNumberOfAuditBoards({ auditBoardCount });
+    }
+
+    helperText(toAudit?: number) {
+        if (!toAudit) {
+            return null;
+        }
+
+        return (
+            <div className='pt-form-helper-text'>
+                There are <b>{ toAudit }</b>  ballot cards to audit in this
+                round.
+            </div>
+        );
+    }
+
+    render() {
+        const { isShown, numberOfBallotsToAudit } = this.props;
+        const { isEnabled } = this.state;
+
+        if (!isShown) {
+            return null;
+        }
+
+        return (
+            <div className='pt-card'>
+                <form onSubmit={ this.handleSubmit }>
+                    <div className='pt-form-group'>
+                        <label className='pt-label pt-ui-text-large'
+                               htmlFor='number-of-audit-boards-input'>
+                            How many audit boards will be auditing?
+                        </label>
+                        <div className='pt-control-group'>
+                            <NumericInput id='number-of-audit-boards-input'
+                                          min={ MIN_AUDIT_BOARDS }
+                                          value={ this.state.auditBoardCount }
+                                          onValueChange={ this.handleChangeAuditBoards }
+                                          disabled={ !isEnabled } />
+                            <button disabled={ !isEnabled } className='pt-button pt-intent-primary'>Enter</button>
+                        </div>
+                        { this.helperText(numberOfBallotsToAudit) }
+                    </div>
+                </form>
+            </div>
+        );
+    }
+};
+
+export default AuditBoardNumberSelector;

--- a/client/src/component/County/Dashboard/Main.tsx
+++ b/client/src/component/County/Dashboard/Main.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import AuditBoardNumberSelector from 'corla/component/County/Dashboard/AuditBoardNumberSelector';
+
 import FileUploadContainer from './FileUploadContainer';
 
 import downloadCvrsToAuditCsv from 'corla/action/county/downloadCvrsToAuditCsv';
@@ -9,26 +11,39 @@ import fetchReport from 'corla/action/county/fetchReport';
 import FileDownloadButtons from 'corla/component/FileDownloadButtons';
 
 
-interface AuditBoardInfoProps {
-    signedIn: boolean;
+interface AuditBoardButtonsProps {
+    numberOfBoards: number;
+    isShown: boolean;
 }
 
-const AuditBoardInfo = (props: AuditBoardInfoProps) => {
-    const { signedIn } = props;
+const AuditBoardButtons = (props: AuditBoardButtonsProps) => {
+    const { isShown, numberOfBoards } = props;
 
-    const icon = signedIn
-               ? <span className='pt-icon pt-intent-success pt-icon-tick-circle' />
-               : <span className='pt-icon pt-intent-danger pt-icon-error' />;
+    if (!isShown) {
+        return null;
+    }
 
-    const text = signedIn ? 'signed in' : 'not signed in';
+    const boardButton = (boardIndex: number) => {
+        return (
+            <button className='pt-button pt-intent-primary pt-icon-people'
+                    key={ boardIndex.toString() }>
+                Audit Board { boardIndex + 1 }
+            </button>
+        );
+    };
+
+    let buttons = [];
+    for (let i = 0; i < numberOfBoards; i++) {
+        buttons.push(boardButton(i));
+    }
 
     return (
         <div className='pt-card'>
-            <span>{ icon } </span>
-            Audit board is <strong>{ text }.</strong>
+            <h5 className='pt-ui-text-large'>Sign in to an audit board</h5>
+            <div className="pt-button-group pt-large corla-spaced">{ buttons }</div>
         </div>
     );
-};
+}
 
 interface MainProps {
     auditBoardSignedIn: boolean;
@@ -126,27 +141,12 @@ const Main = (props: MainProps) => {
                         Download
                     </button>
                 </div>
-                <div>
-                  <AuditBoardInfo signedIn={ auditBoardSignedIn } />
-                  <button
-                      className='pt-button pt-intent-primary audit'
-                      disabled={ auditBoardButtonDisabled }
-                      onClick={ boardSignIn }>
-                      <span className='pt-icon-standard pt-icon-people' />
-                      <span> </span>
-                      Audit Board
-                  </button>
-                  <br/>
-                  <p/>
-                  <button
-                      className='pt-button pt-intent-primary audit'
-                      disabled={ startAuditButtonDisabled }
-                      onClick={ startAudit }>
-                      <span className='pt-icon-standard pt-icon-eye-open' />
-                      <span> </span>
-                      Start Audit
-                  </button>
-                </div>
+                <AuditBoardNumberSelector auditBoardCount={ countyState.auditBoardCount || 1 }
+                                          numberOfBallotsToAudit={ countyState.ballotsRemainingInRound }
+                                          isShown={ !auditBoardButtonDisabled }
+                                          isEnabled={ !countyState.auditBoardCount } />
+                <AuditBoardButtons numberOfBoards={ countyState.auditBoardCount || 1 }
+                                   isShown={ countyState.auditBoardCount != null } />
             </div>
         </div>
     );

--- a/client/src/component/County/Dashboard/Main.tsx
+++ b/client/src/component/County/Dashboard/Main.tsx
@@ -32,7 +32,7 @@ const AuditBoardInfo = (props: AuditBoardInfoProps) => {
 
 interface MainProps {
     auditBoardSignedIn: boolean;
-    auditButtonDisabled: boolean;
+    startAuditButtonDisabled: boolean;
     auditComplete: boolean;
     auditStarted: boolean;
     boardSignIn: OnClick;
@@ -40,14 +40,14 @@ interface MainProps {
     countyState: County.AppState;
     currentRoundNumber: number;
     name: string;
-    signInButtonDisabled: boolean;
+    auditBoardButtonDisabled: boolean;
     startAudit: OnClick;
 }
 
 const Main = (props: MainProps) => {
     const {
         auditBoardSignedIn,
-        auditButtonDisabled,
+        startAuditButtonDisabled,
         auditComplete,
         auditStarted,
         boardSignIn,
@@ -55,7 +55,7 @@ const Main = (props: MainProps) => {
         countyState,
         currentRoundNumber,
         name,
-        signInButtonDisabled,
+        auditBoardButtonDisabled,
         startAudit,
     } = props;
 
@@ -64,7 +64,7 @@ const Main = (props: MainProps) => {
                    + ' continue the audit.';
 
     if (auditBoardSignedIn) {
-        if (auditButtonDisabled) {
+        if (startAuditButtonDisabled) {
             directions = 'Wait for the audit to start.';
         } else {
             if (currentRoundNumber) {
@@ -75,7 +75,7 @@ const Main = (props: MainProps) => {
             }
         }
     } else {
-        if (!signInButtonDisabled) {
+        if (!auditBoardButtonDisabled) {
             directions = 'The Department of State has defined the audit and your list of ballots is now available for'
                        + ' download on this page. The audit board must sign in to advance to the audit.';
         }
@@ -109,7 +109,7 @@ const Main = (props: MainProps) => {
                 { fileUploadContainer }
                 { fileDownloadButtons }
                 <div className='pt-card'>
-                    <div className='pt-ui-text-large'>{ reportType} audit report (CSV)</div>
+                    <div className='pt-ui-text-large'>{ reportType } audit report (CSV)</div>
                     <button
                         className='pt-button  pt-intent-primary'
                         disabled={ !canRenderReport }
@@ -130,7 +130,7 @@ const Main = (props: MainProps) => {
                   <AuditBoardInfo signedIn={ auditBoardSignedIn } />
                   <button
                       className='pt-button pt-intent-primary audit'
-                      disabled={ signInButtonDisabled }
+                      disabled={ auditBoardButtonDisabled }
                       onClick={ boardSignIn }>
                       <span className='pt-icon-standard pt-icon-people' />
                       <span> </span>
@@ -140,7 +140,7 @@ const Main = (props: MainProps) => {
                   <p/>
                   <button
                       className='pt-button pt-intent-primary audit'
-                      disabled={ auditButtonDisabled }
+                      disabled={ startAuditButtonDisabled }
                       onClick={ startAudit }>
                       <span className='pt-icon-standard pt-icon-eye-open' />
                       <span> </span>

--- a/client/src/component/County/Dashboard/Main.tsx
+++ b/client/src/component/County/Dashboard/Main.tsx
@@ -32,7 +32,7 @@ const AuditBoardButtons = (props: AuditBoardButtonsProps) => {
         );
     };
 
-    let buttons = [];
+    const buttons = [];
     for (let i = 0; i < numberOfBoards; i++) {
         buttons.push(boardButton(i));
     }
@@ -40,10 +40,10 @@ const AuditBoardButtons = (props: AuditBoardButtonsProps) => {
     return (
         <div className='pt-card'>
             <h5 className='pt-ui-text-large'>Sign in to an audit board</h5>
-            <div className="pt-button-group pt-large corla-spaced">{ buttons }</div>
+            <div className='pt-button-group pt-large corla-spaced'>{ buttons }</div>
         </div>
     );
-}
+};
 
 interface MainProps {
     auditBoardSignedIn: boolean;

--- a/client/src/component/County/Dashboard/Main.tsx
+++ b/client/src/component/County/Dashboard/Main.tsx
@@ -74,7 +74,7 @@ const Main = (props: MainProps) => {
         startAudit,
     } = props;
 
-    let directions = 'Upload the ballot manifest and cast voter records (CVR) files. These need to be CSV files.'
+    let directions = 'Upload the ballot manifest and cast vote record (CVR) files. These need to be CSV files.'
                    + '\n\nAfter uploading the files wait for an email from the Department of State saying that you can'
                    + ' continue the audit.';
 
@@ -92,7 +92,7 @@ const Main = (props: MainProps) => {
     } else {
         if (!auditBoardButtonDisabled) {
             directions = 'The Department of State has defined the audit and your list of ballots is now available for'
-                       + ' download on this page. The audit board must sign in to advance to the audit.';
+                       + ' download on this page. The audit board(s) must sign in to advance to the audit.';
         }
     }
 

--- a/client/src/component/County/Dashboard/Page.tsx
+++ b/client/src/component/County/Dashboard/Page.tsx
@@ -40,8 +40,8 @@ const CountyDashboardPage = (props: PageProps) => {
         startAudit,
     } = props;
 
-    const auditButtonDisabled = !canAudit || auditComplete;
-    const signInButtonDisabled = !canSignIn;
+    const startAuditButtonDisabled = !canAudit || auditComplete;
+    const auditBoardButtonDisabled = !canSignIn;
 
     return (
         <div>
@@ -55,9 +55,9 @@ const CountyDashboardPage = (props: PageProps) => {
                           canRenderReport={ canRenderReport }
                           countyState={ countyState }
                           currentRoundNumber={ currentRoundNumber }
-                          auditButtonDisabled={ auditButtonDisabled }
+                          startAuditButtonDisabled={ startAuditButtonDisabled }
                           name={ countyInfo.name }
-                          signInButtonDisabled={ signInButtonDisabled }
+                          auditBoardButtonDisabled={ auditBoardButtonDisabled }
                           startAudit={ startAudit } />
                     <Info info={ countyInfo }
                           contests={ contests }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardSignIn.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardSignIn.java
@@ -13,7 +13,6 @@ package us.freeandfair.corla.endpoint;
 
 import static us.freeandfair.corla.asm.ASMEvent.AuditBoardDashboardEvent.SIGN_IN_AUDIT_BOARD_EVENT;
 
-import java.lang.reflect.Type;
 import java.util.List;
 
 import javax.persistence.PersistenceException;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CountyDashboardRefresh.java
@@ -67,7 +67,7 @@ public class CountyDashboardRefresh extends AbstractCountyDashboardEndpoint {
   public String endpointBody(final Request the_request, final Response the_response) {
     try {
       final County county = Main.authentication().authenticatedCounty(the_request);
-          
+
       okJSON(the_response, 
              Main.GSON.toJson(CountyDashboardRefreshResponse.createResponse
                               (Persistence.getByID(county.id(), CountyDashboard.class))));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
@@ -84,7 +84,7 @@ public class IntermediateAuditReport extends AbstractAuditBoardDashboardEndpoint
         cdb.submitIntermediateReport(report);
 
         // TODO: Do we need to sign out all audit boards?
-        for (int i : cdb.auditBoards().keySet()) {
+        for (final int i : cdb.auditBoards().keySet()) {
           cdb.signOutAuditBoard(i);
         }
       }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
@@ -70,7 +70,7 @@ public class IntermediateAuditReport extends AbstractAuditBoardDashboardEndpoint
    */
   @Override
   public String endpointBody(final Request the_request,
-                         final Response the_response) {
+                             final Response the_response) {
     try {
       final IntermediateAuditReportInfo report =
           Main.GSON.fromJson(the_request.body(), IntermediateAuditReportInfo.class);
@@ -82,11 +82,6 @@ public class IntermediateAuditReport extends AbstractAuditBoardDashboardEndpoint
         serverError(the_response, "Could not save intermediate audit report");
       } else {
         cdb.submitIntermediateReport(report);
-
-        // TODO: Do we need to sign out all audit boards?
-        for (final int i : cdb.auditBoards().keySet()) {
-          cdb.signOutAuditBoard(i);
-        }
       }
       Persistence.saveOrUpdate(cdb);
     } catch (final JsonParseException e) {
@@ -98,6 +93,6 @@ public class IntermediateAuditReport extends AbstractAuditBoardDashboardEndpoint
     }
     ok(the_response, "Report submitted");
     // de-authenticate user?
-    return my_endpoint_result.get();    
+    return my_endpoint_result.get();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/IntermediateAuditReport.java
@@ -82,9 +82,11 @@ public class IntermediateAuditReport extends AbstractAuditBoardDashboardEndpoint
         serverError(the_response, "Could not save intermediate audit report");
       } else {
         cdb.submitIntermediateReport(report);
-        // sign the audit board out
-        cdb.signOutAuditBoard();
 
+        // TODO: Do we need to sign out all audit boards?
+        for (int i : cdb.auditBoards().keySet()) {
+          cdb.signOutAuditBoard(i);
+        }
       }
       Persistence.saveOrUpdate(cdb);
     } catch (final JsonParseException e) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetAuditBoardCount.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetAuditBoardCount.java
@@ -22,7 +22,6 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
-import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.persistence.Persistence;
@@ -86,7 +85,7 @@ public class SetAuditBoardCount extends AbstractCountyDashboardEndpoint {
         serverError(response, "could not set audit board count");
       }
 
-      countyDashboard.setAuditBoardCount(input.get("count").intValue());
+      countyDashboard.setAuditBoardCount(input.get("count"));
       Persistence.saveOrUpdate(countyDashboard);
 
       ok(response, String.format("set the number of audit boards to %d",
@@ -106,11 +105,7 @@ public class SetAuditBoardCount extends AbstractCountyDashboardEndpoint {
    *
    * @param body the unmarshalled input
    */
-  private static boolean validateRequestBody(Map<String, Integer> body) {
-    if (body.containsKey("count")) {
-      return true;
-    }
-
-    return false;
+  private static boolean validateRequestBody(final Map<String, Integer> body) {
+    return body.containsKey("count");
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetAuditBoardCount.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetAuditBoardCount.java
@@ -1,0 +1,116 @@
+/*
+ * Colorado RLA System
+ *
+ * @title ColoradoRLA
+ * @copyright 2018 Colorado Department of State
+ * @license SPDX-License-Identifier: AGPL-3.0-or-later
+ * @creator Democracy Works, Inc. <dev@democracy.works>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.endpoint;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import javax.persistence.PersistenceException;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+
+import spark.Request;
+import spark.Response;
+
+import us.freeandfair.corla.Main;
+import us.freeandfair.corla.asm.ASMEvent;
+import us.freeandfair.corla.model.County;
+import us.freeandfair.corla.model.CountyDashboard;
+import us.freeandfair.corla.persistence.Persistence;
+
+/**
+ * The endpoint for setting the number of audit boards for a given county.
+ *
+ * @author Democracy Works, Inc. <dev@democracy.works>
+ */
+// TODO: This rule and checkstyle conflict. We need to pick one or the other,
+// but with both we need a suppression rule for one of them.
+@SuppressWarnings({"PMD.AtLeastOneConstructor"})
+public class SetAuditBoardCount extends AbstractCountyDashboardEndpoint {
+  /**
+   * Type information for easy unmarshalling of the request body.
+   */
+  private static final Type TYPE_TOKEN =
+      new TypeToken<Map<String, Integer>>() { }.getType();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public EndpointType endpointType() {
+    // TODO: Easy to make this PUT?
+    return EndpointType.POST;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String endpointName() {
+    return "/set-audit-board-count";
+  }
+
+  /**
+   * Set the number of audit boards for a given county.
+   *
+   * @param request HTTP request
+   * @param response HTTP response
+   */
+  @Override
+  public String endpointBody(final Request request, final Response response) {
+    try {
+      final Map<String, Integer> input =
+          Main.GSON.fromJson(request.body(), TYPE_TOKEN);
+
+      final County county = Main.authentication().authenticatedCounty(request);
+
+      if (!validateRequestBody(input)) {
+        badDataContents(response, "malformed audit board count request");
+      }
+
+      final CountyDashboard countyDashboard =
+          Persistence.getByID(county.id(), CountyDashboard.class);
+
+      if (countyDashboard == null) {
+        Main.LOGGER.error(String.format("could not get county dashboard [id=%d]",
+            county.id()));
+        serverError(response, "could not set audit board count");
+      }
+
+      countyDashboard.setAuditBoardCount(input.get("count").intValue());
+      Persistence.saveOrUpdate(countyDashboard);
+
+      ok(response, String.format("set the number of audit boards to %d",
+          countyDashboard.auditBoardCount()));
+    } catch (final PersistenceException e) {
+      Main.LOGGER.error("unable to set audit board count", e);
+      serverError(response, "unable to set audit board count");
+    } catch (final JsonParseException e) {
+      badDataContents(response, "malformed audit board count request");
+    }
+
+    return my_endpoint_result.get();
+  }
+
+  /**
+   * Check that the unmarshalled input looks like we expect it to.
+   *
+   * @param body the unmarshalled input
+   */
+  private static boolean validateRequestBody(Map<String, Integer> body) {
+    if (body.containsKey("count")) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
@@ -207,6 +207,14 @@ public class SignOffAuditRound extends AbstractAuditBoardDashboardEndpoint {
                         DoSDashboardASM.class, 
                         DoSDashboardASM.IDENTITY);
     }
-    the_cdb.signOutAuditBoard();
+
+    // TODO: Do we need to sign out all audit boards?
+    //
+    // We only need to sign out all audit boards when the entire audit is
+    // complete; we probably need an intermediate step to sign off on a given
+    // audit board’s portion of work.
+    for (int i : the_cdb.auditBoards().keySet()) {
+      the_cdb.signOutAuditBoard(i);
+    }
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
@@ -213,7 +213,7 @@ public class SignOffAuditRound extends AbstractAuditBoardDashboardEndpoint {
     // We only need to sign out all audit boards when the entire audit is
     // complete; we probably need an intermediate step to sign off on a given
     // audit board’s portion of work.
-    for (int i : the_cdb.auditBoards().keySet()) {
+    for (final int i : the_cdb.auditBoards().keySet()) {
       the_cdb.signOutAuditBoard(i);
     }
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UpdateAuditInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/UpdateAuditInfo.java
@@ -42,6 +42,13 @@ import us.freeandfair.corla.persistence.Persistence;
 @SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.CyclomaticComplexity"})
 public class UpdateAuditInfo extends AbstractDoSDashboardEndpoint {
   /**
+   * Uploaded file attribute
+   *
+   * Factored out due to the PMD rule AvoidDuplicateLiterals
+   */
+  private static final String UPLOAD_FILE_ATTR = "upload_file";
+
+  /**
    * The event to return for this endpoint.
    */
   private final ThreadLocal<ASMEvent> my_event = new ThreadLocal<ASMEvent>();
@@ -90,7 +97,7 @@ public class UpdateAuditInfo extends AbstractDoSDashboardEndpoint {
       object = parser.parse(s).getAsJsonObject();
       if (hasFile(object)){
         return object
-          .getAsJsonArray("upload_file")
+          .getAsJsonArray(UPLOAD_FILE_ATTR)
           .get(0)
           .getAsJsonObject()
           .get("contents")
@@ -107,9 +114,9 @@ public class UpdateAuditInfo extends AbstractDoSDashboardEndpoint {
 
   private Boolean hasFile(final JsonObject o) {
     return o != null
-        && o.getAsJsonArray("upload_file") != null
-        && o.getAsJsonArray("upload_file").size() > 0
-        && o.getAsJsonArray("upload_file").get(0) != null;
+        && o.getAsJsonArray(UPLOAD_FILE_ATTR) != null
+        && o.getAsJsonArray(UPLOAD_FILE_ATTR).size() > 0
+        && o.getAsJsonArray(UPLOAD_FILE_ATTR).get(0) != null;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -73,11 +73,16 @@ public class CountyDashboardRefreshResponse {
    * @todo this needs to be connected to something
    */
   private final SortedMap<String, String> my_general_information;
-  
+
   /**
-   * The audit board members.
+   * The desired number of audit boards.
    */
-  private final AuditBoard my_audit_board;
+  private final Integer my_audit_board_count;
+
+  /**
+   * The audit boards.
+   */
+  private final Map<Integer, AuditBoard> my_audit_boards;
   
   /**
    * The ballot manifest file.
@@ -182,7 +187,8 @@ public class CountyDashboardRefreshResponse {
    * @param the_audit_board_asm_state The audit board ASM state.
    * @param the_general_information The general information.
    * @param the_risk_limit The risk limit.
-   * @param the_audit_board The current audit board.
+   * @param the_audit_board_count The desired number of audit boards.
+   * @param the_audit_boards The current audit boards.
    * @param the_ballot_manifest_file The ballot manifest file.
    * @param the_cvr_export_file The CVR export file.
    * @param the_contests The contests.
@@ -217,7 +223,8 @@ public class CountyDashboardRefreshResponse {
                                            final ASMState the_audit_board_asm_state,
                                            final SortedMap<String, String> 
                                                the_general_information,
-                                           final AuditBoard the_audit_board, 
+                                           final Integer the_audit_board_count,
+                                           final Map<Integer, AuditBoard> the_audit_boards,
                                            final UploadedFile the_ballot_manifest_file,
                                            final UploadedFile the_cvr_export_file,
                                            final List<Long> the_contests,
@@ -231,9 +238,9 @@ public class CountyDashboardRefreshResponse {
                                            final Integer the_cvr_export_count,
                                            final ImportStatus the_cvr_import_status,
                                            final Integer the_audited_ballot_count,
-                                           final Map<AuditSelection, Integer> 
-                                               the_discrepancy_count, 
-                                           final Map<AuditSelection, Integer> 
+                                           final Map<AuditSelection, Integer>
+                                               the_discrepancy_count,
+                                           final Map<AuditSelection, Integer>
                                                the_disagreement_count,
                                            final Long the_ballot_under_audit_id,
                                            final Integer the_audited_prefix_length,
@@ -244,7 +251,8 @@ public class CountyDashboardRefreshResponse {
     my_asm_state = the_asm_state;
     my_audit_board_asm_state = the_audit_board_asm_state;
     my_general_information = the_general_information;
-    my_audit_board = the_audit_board;
+    my_audit_board_count = the_audit_board_count;
+    my_audit_boards = the_audit_boards;
     my_ballot_manifest_file = the_ballot_manifest_file;
     my_cvr_export_file = the_cvr_export_file;
     my_contests = the_contests;
@@ -332,7 +340,8 @@ public class CountyDashboardRefreshResponse {
                                               asm.currentState(),
                                               audit_board_asm.currentState(),
                                               general_information,
-                                              the_dashboard.currentAuditBoard(),
+                                              the_dashboard.auditBoardCount(),
+                                              the_dashboard.auditBoards(),
                                               the_dashboard.manifestFile(),
                                               the_dashboard.cvrFile(),
                                               contests,
@@ -397,7 +406,8 @@ public class CountyDashboardRefreshResponse {
                                               asm.currentState(),
                                               audit_board_asm.currentState(),
                                               null,
-                                              the_dashboard.currentAuditBoard(),
+                                              the_dashboard.auditBoardCount(),
+                                              the_dashboard.auditBoards(),
                                               the_dashboard.manifestFile(),
                                               the_dashboard.cvrFile(),
                                               null,

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -45,7 +45,6 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
-import us.freeandfair.corla.Main;
 import us.freeandfair.corla.model.ImportStatus.ImportState;
 import us.freeandfair.corla.persistence.AuditSelectionIntegerMapConverter;
 import us.freeandfair.corla.persistence.PersistentEntity;
@@ -394,7 +393,7 @@ public class CountyDashboard implements PersistentEntity {
    *
    * @param count number of audit boards
    */
-  public void setAuditBoardCount(Integer count) {
+  public void setAuditBoardCount(final Integer count) {
     this.auditBoardCount = count;
   }
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -38,12 +38,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
+import us.freeandfair.corla.Main;
 import us.freeandfair.corla.model.ImportStatus.ImportState;
 import us.freeandfair.corla.persistence.AuditSelectionIntegerMapConverter;
 import us.freeandfair.corla.persistence.PersistentEntity;
@@ -161,22 +163,23 @@ public class CountyDashboard implements PersistentEntity {
    * The timestamp for the start of the audit.
    */
   private Instant my_audit_timestamp; 
-  
+
   /**
-   * The members of the audit board.
+   * The audit boards.
    */
   @ElementCollection(fetch = FetchType.LAZY)
-  @OrderColumn(name = INDEX)
+  @MapKeyColumn(name = INDEX)
   @CollectionTable(name = "audit_board",
                    joinColumns = @JoinColumn(name = DASHBOARD_ID, 
                                              referencedColumnName = MY_ID))
-  private List<AuditBoard> my_audit_boards = new ArrayList<>();
- 
+  private Map<Integer, AuditBoard> my_audit_boards = new HashMap<>();
+
   /**
-   * The current audit board.
+   * The number of audit boards.
    */
-  private Integer my_current_audit_board_index;
-  
+  @Column(name="audit_board_count")
+  private Integer auditBoardCount;
+
   /**
    * The audit rounds.
    */
@@ -377,26 +380,31 @@ public class CountyDashboard implements PersistentEntity {
    */
   public void setAuditTimestamp(final Instant the_timestamp) {
     my_audit_timestamp = the_timestamp;
-  }  
+  }
 
   /**
-   * @return the current audit board.
+   * @return the number of audit boards.
    */
-  public AuditBoard currentAuditBoard() {
-    if (my_current_audit_board_index == null) {
-      return null; 
-    } else {
-      return my_audit_boards.get(my_current_audit_board_index);
-    }
+  public Integer auditBoardCount() {
+    return this.auditBoardCount;
   }
-  
+
+  /**
+   * Set the expected number of audit boards.
+   *
+   * @param count number of audit boards
+   */
+  public void setAuditBoardCount(Integer count) {
+    this.auditBoardCount = count;
+  }
+
   /**
    * @return the entire list of audit boards.
    */
-  public List<AuditBoard> auditBoards() {
-    return Collections.unmodifiableList(my_audit_boards);
+  public Map<Integer, AuditBoard> auditBoards() {
+    return Collections.unmodifiableMap(my_audit_boards);
   }
-  
+
   /**
    * Signs in the specified audit board as of the present time; 
    * the supplied set of electors must be the full set of electors on
@@ -405,32 +413,52 @@ public class CountyDashboard implements PersistentEntity {
    * 
    * @param the_members The members.
    */
-  public void signInAuditBoard(final List<Elector> the_members) {
-    if (my_current_audit_board_index == null) {
-      my_current_audit_board_index = my_audit_boards.size();
-    } else {
-      final AuditBoard current = my_audit_boards.get(my_current_audit_board_index);
-      current.setSignOutTime(Instant.now());
-      my_current_audit_board_index = my_current_audit_board_index + 1;
+  public void signInAuditBoard(final Integer index,
+                               final List<Elector> the_members) {
+    final AuditBoard currentBoard = my_audit_boards.get(index);
+    final AuditBoard newBoard = new AuditBoard(the_members, Instant.now());
+
+    if (currentBoard != null) {
+      this.signOutAuditBoard(index);
     }
-    my_audit_boards.add(new AuditBoard(the_members, Instant.now()));
+
+    my_audit_boards.put(index, newBoard);
   }
-  
+
   /**
    * Signs out the current audit board.
-   * 
-   * @exception IllegalStateException if no audit board is signed in.
+   *
+   * If no audit board is present at the given index, nothing is changed.
    */
-  public void signOutAuditBoard() {
-    if (my_current_audit_board_index == null) {
-      throw new IllegalArgumentException("no audit board signed in");
-    } else {
-      final AuditBoard current = my_audit_boards.get(my_current_audit_board_index);
-      current.setSignOutTime(Instant.now());
-      my_current_audit_board_index = NO_CONTENT;
+  public void signOutAuditBoard(final Integer index) {
+    final AuditBoard currentBoard = my_audit_boards.get(index);
+
+    if (currentBoard != null) {
+      currentBoard.setSignOutTime(Instant.now());
     }
   }
-  
+
+  /**
+   * Test if the desired number of audit boards have signed in.
+   *
+   * Note: Currently does not do anything about more audit boards than
+   * explicitly asked for.
+   *
+   * @return boolean
+   */
+  public boolean areAuditBoardsSignedIn() {
+    boolean result = true;
+
+    for (int i = 0; i < this.auditBoardCount(); i++) {
+      if (my_audit_boards.get(i) == null) {
+        result = false;
+        break;
+      }
+    }
+
+    return result;
+  }
+
   /**
    * @return all the audit rounds.
    */

--- a/server/eclipse-project/src/main/resources/us/freeandfair/corla/endpoint/endpoint_classes
+++ b/server/eclipse-project/src/main/resources/us/freeandfair/corla/endpoint/endpoint_classes
@@ -36,6 +36,7 @@ us.freeandfair.corla.endpoint.ReportBallotsToAudit
 us.freeandfair.corla.endpoint.RiskLimitForComparisonAudits
 us.freeandfair.corla.endpoint.Root
 us.freeandfair.corla.endpoint.SelectContestsForAudit
+us.freeandfair.corla.endpoint.SetAuditBoardCount
 us.freeandfair.corla.endpoint.SetContestNames
 us.freeandfair.corla.endpoint.SetRandomSeed
 us.freeandfair.corla.endpoint.SignOffAuditRound


### PR DESCRIPTION
This represents the work done so far on the multiple audit board support epic. Note that the base branch for this PR is the branch that will contain the work for the epic, as completing individual cards will not leave in the application in a deliverable state, and so cannot be individually merged to master.

**Features:**

- Audit boards are now represented as a map of audit board index number to audit board object
- Operations on county audit boards all now require an index to be specified to log the user in to a particular audit board.
- UI for selecting the number of audit boards and the buttons which will eventually allow the separate audit boards to log in now exists.

**References:**

https://www.pivotaltracker.com/story/show/160018700