### PR TITLE
Allow audit board members to sign in to a particular audit board

### DIFF
--- a/client/src/component/County/AuditBoard/Page.tsx
+++ b/client/src/component/County/AuditBoard/Page.tsx
@@ -11,6 +11,7 @@ import isValidAuditBoard from 'corla/selector/county/isValidAuditBoard';
 
 interface PageProps {
     auditBoard: AuditBoard;
+    auditBoardIndex: number;
     countyName: string;
 }
 
@@ -35,14 +36,19 @@ class AuditBoardSignInPage extends React.Component<PageProps, PageState> {
     };
 
     public render() {
-        const { auditBoard, countyName } = this.props;
+        const {
+          auditBoard,
+          auditBoardIndex,
+          countyName,
+        } = this.props;
 
         if (!auditBoard) {
             return <div />;
         }
 
-        // TODO: Set the index according to the button clicked...
-        const submit = () => auditBoardSignIn(0, this.state.form);
+        const submit = () => {
+          auditBoardSignIn(auditBoardIndex, this.state.form);
+        };
 
         const disableButton = !isValidAuditBoard(this.state.form);
 
@@ -50,11 +56,14 @@ class AuditBoardSignInPage extends React.Component<PageProps, PageState> {
             <div>
                 <CountyNav />
                 <div>
-                    <h2>Audit Board</h2>
+                    <h2>Audit Board { auditBoardIndex + 1 }</h2>
                     <div className='pt-card'>
-                        <h5>Enter the full names and party affiliations of each member of
-                        the { countyName } County Audit Board who will be conducting this
-                        audit today:</h5>
+                        <span className='pt-ui-text-large'>
+                            Enter the full names and party affiliations of each
+                            member of the { countyName } County Audit Board
+                            { ' ' + (auditBoardIndex + 1) } who will be
+                            conducting this audit today.
+                         </span>
                     </div>
                 </div>
                 <SignInForm

--- a/client/src/component/County/AuditBoard/PageContainer.tsx
+++ b/client/src/component/County/AuditBoard/PageContainer.tsx
@@ -21,6 +21,7 @@ interface ContainerProps {
     countyName: string;
     hasAuditedAnyBallot: boolean;
     history: History;
+    match: any;
 }
 
 class AuditBoardSignInContainer extends React.Component<ContainerProps> {
@@ -31,6 +32,7 @@ class AuditBoardSignInContainer extends React.Component<ContainerProps> {
             countyName,
             hasAuditedAnyBallot,
             history,
+            match,
         } = this.props;
 
         if (auditBoardSignedIn) {
@@ -39,13 +41,16 @@ class AuditBoardSignInContainer extends React.Component<ContainerProps> {
 
             return (
                 <SignedInPage auditBoard={ auditBoard }
+                              auditBoardIndex={ parseInt(match.params.id, 10) }
                               auditBoardStartOrContinue={ auditBoardStartOrContinue }
                               countyName={ countyName }
                               hasAuditedAnyBallot={ hasAuditedAnyBallot } />
             );
         }
 
-        return <AuditBoardPage { ...this.props } />;
+        return <AuditBoardPage auditBoard={ auditBoard }
+                               auditBoardIndex={ parseInt(match.params.id, 10) }
+                               countyName={ countyName } />;
     }
 }
 

--- a/client/src/component/County/AuditBoard/SignedInPage.tsx
+++ b/client/src/component/County/AuditBoard/SignedInPage.tsx
@@ -7,6 +7,7 @@ import auditBoardSignOut from 'corla/action/county/auditBoardSignOut';
 
 interface PageProps {
     auditBoard: AuditBoard;
+    auditBoardIndex: number;
     auditBoardStartOrContinue: OnClick;
     countyName: string;
     hasAuditedAnyBallot: boolean;
@@ -15,6 +16,7 @@ interface PageProps {
 const SignedInPage = (props: PageProps) => {
     const {
         auditBoard,
+        auditBoardIndex,
         auditBoardStartOrContinue,
         countyName,
         hasAuditedAnyBallot,
@@ -26,7 +28,7 @@ const SignedInPage = (props: PageProps) => {
         <div>
             <CountyNav />
             <div>
-                <h2>Audit Board</h2>
+                <h2>Audit Board { auditBoardIndex + 1 }</h2>
                 <div className='pt-card'>
                     <h5>The Audit Board members below are signed in.
                     To sign the Audit Board out, click the "Sign Out" button below.</h5>

--- a/client/src/component/County/Dashboard/Main.tsx
+++ b/client/src/component/County/Dashboard/Main.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { History } from 'history';
+
 import AuditBoardNumberSelector from 'corla/component/County/Dashboard/AuditBoardNumberSelector';
 
 import FileUploadContainer from './FileUploadContainer';
@@ -12,21 +14,29 @@ import FileDownloadButtons from 'corla/component/FileDownloadButtons';
 
 
 interface AuditBoardButtonsProps {
-    numberOfBoards: number;
+    history: History;
     isShown: boolean;
+    numberOfBoards: number;
 }
 
 const AuditBoardButtons = (props: AuditBoardButtonsProps) => {
-    const { isShown, numberOfBoards } = props;
+    const { history, isShown, numberOfBoards } = props;
 
     if (!isShown) {
         return null;
     }
 
+    const handleButtonClick = (e: any, boardIndex: number) => {
+        e.preventDefault();
+
+        history.push('/county/board/' + boardIndex);
+    };
+
     const boardButton = (boardIndex: number) => {
         return (
             <button className='pt-button pt-intent-primary pt-icon-people'
-                    key={ boardIndex.toString() }>
+                    key={ boardIndex.toString() }
+                    onClick={ (e: any) => handleButtonClick(e, boardIndex) }>
                 Audit Board { boardIndex + 1 }
             </button>
         );
@@ -46,32 +56,32 @@ const AuditBoardButtons = (props: AuditBoardButtonsProps) => {
 };
 
 interface MainProps {
+    auditBoardButtonDisabled: boolean;
     auditBoardSignedIn: boolean;
-    startAuditButtonDisabled: boolean;
     auditComplete: boolean;
     auditStarted: boolean;
-    boardSignIn: OnClick;
     canRenderReport: boolean;
     countyState: County.AppState;
     currentRoundNumber: number;
+    history: History;
     name: string;
-    auditBoardButtonDisabled: boolean;
     startAudit: OnClick;
+    startAuditButtonDisabled: boolean;
 }
 
 const Main = (props: MainProps) => {
     const {
+        auditBoardButtonDisabled,
         auditBoardSignedIn,
-        startAuditButtonDisabled,
         auditComplete,
         auditStarted,
-        boardSignIn,
         canRenderReport,
         countyState,
         currentRoundNumber,
+        history,
         name,
-        auditBoardButtonDisabled,
         startAudit,
+        startAuditButtonDisabled,
     } = props;
 
     let directions = 'Upload the ballot manifest and cast vote record (CVR) files. These need to be CSV files.'
@@ -145,8 +155,9 @@ const Main = (props: MainProps) => {
                                           numberOfBallotsToAudit={ countyState.ballotsRemainingInRound }
                                           isShown={ !auditBoardButtonDisabled }
                                           isEnabled={ !countyState.auditBoardCount } />
-                <AuditBoardButtons numberOfBoards={ countyState.auditBoardCount || 1 }
-                                   isShown={ countyState.auditBoardCount != null } />
+                <AuditBoardButtons history={ history }
+                                   isShown={ countyState.auditBoardCount != null }
+                                   numberOfBoards={ countyState.auditBoardCount || 1 } />
             </div>
         </div>
     );

--- a/client/src/component/County/Dashboard/Page.tsx
+++ b/client/src/component/County/Dashboard/Page.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
+import { History } from 'history';
+
 import LicenseFooter from 'corla/component/LicenseFooter';
 
 import CountyNav from '../Nav';
@@ -13,7 +15,6 @@ interface PageProps {
     auditBoardSignedIn: boolean;
     auditComplete: boolean;
     auditStarted: boolean;
-    boardSignIn: OnClick;
     canAudit: boolean;
     canRenderReport: boolean;
     canSignIn: boolean;
@@ -21,6 +22,7 @@ interface PageProps {
     countyInfo: CountyInfo;
     countyState: County.AppState;
     currentRoundNumber: number;
+    history: History;
     startAudit: OnClick;
 }
 
@@ -29,7 +31,6 @@ const CountyDashboardPage = (props: PageProps) => {
         auditBoardSignedIn,
         auditComplete,
         auditStarted,
-        boardSignIn,
         canAudit,
         canRenderReport,
         canSignIn,
@@ -37,6 +38,7 @@ const CountyDashboardPage = (props: PageProps) => {
         countyInfo,
         countyState,
         currentRoundNumber,
+        history,
         startAudit,
     } = props;
 
@@ -51,10 +53,10 @@ const CountyDashboardPage = (props: PageProps) => {
                     <Main auditComplete={ auditComplete }
                           auditStarted={ auditStarted }
                           auditBoardSignedIn={ auditBoardSignedIn }
-                          boardSignIn={ boardSignIn }
                           canRenderReport={ canRenderReport }
                           countyState={ countyState }
                           currentRoundNumber={ currentRoundNumber }
+                          history={ history }
                           startAuditButtonDisabled={ startAuditButtonDisabled }
                           name={ countyInfo.name }
                           auditBoardButtonDisabled={ auditBoardButtonDisabled }

--- a/client/src/component/County/Dashboard/PageContainer.tsx
+++ b/client/src/component/County/Dashboard/PageContainer.tsx
@@ -64,13 +64,11 @@ class CountyDashboardContainer extends React.Component<DashboardProps> {
         }
 
         const countyInfo = counties[countyState.id];
-        const boardSignIn = () => history.push('/county/board');
         const startAudit = () => history.push('/county/audit');
 
         const props = {
             allRoundsComplete,
             auditStarted,
-            boardSignIn,
             canAudit,
             canRenderReport,
             canSignIn,

--- a/client/src/component/County/NavMenu.tsx
+++ b/client/src/component/County/NavMenu.tsx
@@ -34,11 +34,6 @@ export default class CountyNavMenu extends React.Component {
                 />
                 <li className='pt-menu-divider' />
                 <MenuItem
-                    text='Audit Board'
-                    path='/county/board'
-                    icon='pt-icon-people'
-                />
-                <MenuItem
                     text='Audit'
                     path='/county/audit'
                     icon='pt-icon-eye-open'

--- a/client/src/component/RootContainer.tsx
+++ b/client/src/component/RootContainer.tsx
@@ -53,7 +53,7 @@ export class RootContainer extends React.Component<RootContainerProps> {
                                     path='/county'
                                     page={ CountyDashboardPageContainer } />
                         <LoginRoute exact
-                                    path='/county/board'
+                                    path='/county/board/:id'
                                     page={ AuditBoardPageContainer } />
                         <LoginRoute exact
                                     path='/county/audit'

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardSignOut.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/AuditBoardSignOut.java
@@ -34,7 +34,7 @@ import us.freeandfair.corla.util.SuppressFBWarnings;
  * @author Daniel M. Zimmerman <dmz@freeandFair.us>
  * @version 1.0.0
  */
-@SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.ExcessiveImports"})
+@SuppressWarnings({"PMD.AtLeastOneConstructor"})
 public class AuditBoardSignOut extends AbstractAuditBoardDashboardEndpoint {
   /**
    * {@inheritDoc}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -425,7 +425,7 @@ public class CountyDashboard implements PersistentEntity {
   }
 
   /**
-   * Signs out the current audit board.
+   * Signs out the audit board at index.
    *
    * If no audit board is present at the given index, nothing is changed.
    */
@@ -434,14 +434,29 @@ public class CountyDashboard implements PersistentEntity {
 
     if (currentBoard != null) {
       currentBoard.setSignOutTime(Instant.now());
+      my_audit_boards.remove(index);
+    }
+  }
+
+  /**
+   * Signs out all audit boards.
+   */
+  public void signOutAllAuditBoards() {
+    for (final int i : my_audit_boards.keySet()) {
+      this.signOutAuditBoard(i);
     }
   }
 
   /**
    * Test if the desired number of audit boards have signed in.
    *
-   * Note: Currently does not do anything about more audit boards than
-   * explicitly asked for.
+   * Note: Only works properly for indexes less than the current audit board
+   * count in case there are orphaned boards outside of the current expected
+   * key range, because just counting the number of keys in the audit board map
+   * might yield the wrong answer if there are orphaned audit boards.
+   *
+   * Use signOutAllAuditBoards to properly clear out the data structure holding
+   * all audit boards, signing out audit boards as necessary.
    *
    * @return boolean
    */


### PR DESCRIPTION
This PR edges us closer to multiple audit board support in the following ways:

- Once the admin has set the number of audit boards for the round, the audit board sign in buttons at the bottom of the page should adjust to match the number of boards selected and become active.
- When the county admin clicks a particular audit board button from that page, they should be redirected to the audit board sign-in page for that audit board
- The page title "Audit Board" should now also contain the number of the specific audit board (e.g. "Audit Board 1")

**References:**

https://www.pivotaltracker.com/story/show/160020629

**TODO:**

- [x] Merge base branch into epic branch
- [x] Rebase this onto epic branch