### PR TITLE
Divide county pull list among the audit boards

### DIFF
--- a/client/src/component/County/Dashboard/Main.tsx
+++ b/client/src/component/County/Dashboard/Main.tsx
@@ -146,7 +146,7 @@ const Main = (props: MainProps) => {
                     <div className='pt-ui-text-large'>List of ballots to audit (CSV)</div>
                     <button
                         className='pt-button  pt-intent-primary'
-                        disabled={ !canRenderReport }
+                        disabled={ countyState.auditBoardCount == null }
                         onClick={ downloadCsv }>
                         Download
                     </button>

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -94,16 +94,32 @@ public final class BallotSelection {
     return cvr;
   }
 
-  /** render cvrs using BallotManifestInfo **/
+  /**
+   * Joins provided CVRs to the ballot manifest.
+   *
+   * Produces a list of CVRToAuditResponse elements which represent the CVRs
+   * augmented with ballot manifest data.
+   *
+   * @return CVRs joind with ballot manifest data
+   */
   public static List<CVRToAuditResponse>
       toResponseList(final List<CastVoteRecord> cvrs) {
     return toResponseList(cvrs, BallotManifestInfoQueries::locationFor);
   }
 
-  /** render cvrs using BallotManifestInfo **/
+
+  /**
+   * Joins provided CVRs to the ballot manifest.
+   *
+   * Produces a list of CVRToAuditResponse elements which represent the CVRs
+   * augmented with ballot manifest data.
+   *
+   * Uses a passed-in BallotManifestInfo query.
+   *
+   * @return CVRs joind with ballot manifest data
+   */
   public static List<CVRToAuditResponse>
-      toResponseList(final List<CastVoteRecord> cvrs,
-                   final BMILOCQ bmiq) {
+      toResponseList(final List<CastVoteRecord> cvrs, final BMILOCQ bmiq) {
 
     final List<CVRToAuditResponse> responses = new LinkedList<CVRToAuditResponse>();
 
@@ -112,9 +128,7 @@ public final class BallotSelection {
       final BallotManifestInfo bmi =
           bmiMaybe(bmiq.apply(cvr), Long.valueOf(cvr.cvrNumber()));
 
-      responses.add(toResponse(i,
-                               bmi,
-                               cvr));
+      responses.add(toResponse(i, bmi, cvr));
       i++;
     }
     return responses;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -21,8 +21,6 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.crypto.PseudoRandomNumberGenerator;
@@ -44,6 +42,7 @@ import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.BallotManifestInfoQueries;
 import us.freeandfair.corla.query.CastVoteRecordQueries;
 import us.freeandfair.corla.query.CountyContestResultQueries;
+import us.freeandfair.corla.util.BallotSequencer;
 
 /**
  * Controller methods relevant to comparison audits.
@@ -293,31 +292,39 @@ public final class ComparisonAuditController {
   }
 
   /**
-   * Compute the ballot (cards) for audit, for a particular county and
-   * round. The returned list does not have duplicates, and is in _arbitrary order_.
+   * Return the ballot cards to audit for a particular county and round.
    *
-   * @param the_cdb The dashboard.
-   * @param the_round The round number.
-   * @param the_audited True to include already-audited ballots, false otherwise.
-   * @return the list of ballot (cards) for audit; if the query does not result
-   * in any ballot (cards), as when the round number is invalid, the returned list
-   * is empty.
+   * The returned list will not have duplicates and is in an undefined order.
+   *
+   * @param countyDashboard county dashboard owning the rounds
+   * @param roundNumber 1-indexed round number
+   * @param includeAudited include audited ballots
+   *
+   * @return the list of ballot cards for audit. If the query does not result in
+   *         any ballot cards, for instance when the round number is invalid,
+   *         the returned list is empty.
    */
-  @SuppressWarnings("PMD.UselessParentheses")
-  public static List<CastVoteRecord> ballotsToAudit(final CountyDashboard the_cdb,
-                                                    final int the_round,
-                                                    final boolean the_audited) {
-    if (the_round <= 0 || the_cdb.rounds().size() < the_round) {
-      return new ArrayList<>();
+  // TODO: includeAudited is unused
+  public static List<CastVoteRecord>
+      ballotsToAudit(final CountyDashboard countyDashboard,
+                     final int roundNumber,
+                     final boolean includeAudited) {
+    final Round round;
+
+    try {
+      // roundNumber is 1-based
+      round = countyDashboard.rounds().get(roundNumber - 1);
+    } catch (IndexOutOfBoundsException e) {
+      return new ArrayList<CastVoteRecord>();
     }
-    // round numbers are 1-based, not 0-based
-    final Round round = the_cdb.rounds().get(the_round - 1);
 
-    // we already have the list of CVR IDs for the round
-    final List<CastVoteRecord> cvrs = CastVoteRecordQueries.get(round.ballotSequence());
+    final List<CastVoteRecord> cvrs =
+        CastVoteRecordQueries.get(round.ballotSequence());
 
+    // PERF: Is this a hotspot? We can figure out the audit flag using a single
+    // query.
     for (final CastVoteRecord cvr : cvrs) {
-      cvr.setAuditFlag(audited(the_cdb, cvr));
+      cvr.setAuditFlag(audited(countyDashboard, cvr));
     }
 
     return cvrs;
@@ -384,18 +391,14 @@ public final class ComparisonAuditController {
         audit_subsequence_ids.add(cvr.id());
       }
 
-      // deduplicate the CVRs and put them in ballot order
-      final SortedSet<CastVoteRecord> sorted_deduplicated_cvrs =
-          new TreeSet<CastVoteRecord>();
-      sorted_deduplicated_cvrs.addAll(cvrs_to_audit);
-      final List<Long> ballot_ids_to_audit = new ArrayList<Long>();
-      for (final CastVoteRecord cvr : sorted_deduplicated_cvrs) {
-        ballot_ids_to_audit.add(cvr.id());
-      }
+      // De-duplicate the CVRs and put them in "pull list" order
+      final List<Long> ballotIdsToAudit =
+          BallotSequencer.sortAndDeduplicateCVRs(cvrs_to_audit);
 
-      the_cdb.startRound(sorted_deduplicated_cvrs.size(),
-                         to_audit, 0,
-                         ballot_ids_to_audit,
+      the_cdb.startRound(ballotIdsToAudit.size(),
+                         to_audit,
+                         0,
+                         ballotIdsToAudit,
                          audit_subsequence_ids);
       updateRound(the_cdb, the_cdb.currentRound());
       updateCVRUnderAudit(the_cdb);
@@ -437,16 +440,16 @@ public final class ComparisonAuditController {
         getCVRsInAuditSequence(the_cdb.county(), start_index, the_round_length);
 
     List<CastVoteRecord> extra_cvrs = new_cvrs;
-    final SortedSet<CastVoteRecord> sorted_deduplicated_new_cvrs =
-        new TreeSet<CastVoteRecord>();
-    sorted_deduplicated_new_cvrs.addAll(new_cvrs);
+    final Set<CastVoteRecord> deduplicated_new_cvrs =
+        new HashSet<CastVoteRecord>();
+    deduplicated_new_cvrs.addAll(new_cvrs);
     while (!extra_cvrs.isEmpty() &&
-           sorted_deduplicated_new_cvrs.size() < the_round_length) {
+           deduplicated_new_cvrs.size() < the_round_length) {
       extra_cvrs =
           getCVRsInAuditSequence(the_cdb.county(), start_index + new_cvrs.size(),
-                                 the_round_length - sorted_deduplicated_new_cvrs.size());
+                                 the_round_length - deduplicated_new_cvrs.size());
       new_cvrs.addAll(extra_cvrs);
-      sorted_deduplicated_new_cvrs.addAll(extra_cvrs);
+      deduplicated_new_cvrs.addAll(extra_cvrs);
     }
 
     // the IDs of the CVRs to audit, in audit sequence order
@@ -462,25 +465,29 @@ public final class ComparisonAuditController {
       for (final Long cvr_id : round.ballotSequence()) {
         if (unique_new_cvr_ids.contains(cvr_id)) {
           unique_new_cvr_ids.remove(cvr_id);
-          sorted_deduplicated_new_cvrs.remove(Persistence.getByID(cvr_id,
-                                                                  CastVoteRecord.class));
+          deduplicated_new_cvrs.remove(
+              Persistence.getByID(cvr_id, CastVoteRecord.class));
         }
       }
     }
 
-    if (sorted_deduplicated_new_cvrs.isEmpty()) {
+    if (deduplicated_new_cvrs.isEmpty()) {
       return false;
     } else {
       Main.LOGGER.info("starting audit round " + (rounds.size() + 1) + " for county " +
           the_cdb.id() + " at audit sequence number " + start_index +
-          " with " + sorted_deduplicated_new_cvrs.size() + " ballots to audit");
-      final List<Long> ballot_ids_to_audit = new ArrayList<>();
-      for (final CastVoteRecord cvr : sorted_deduplicated_new_cvrs) {
-        ballot_ids_to_audit.add(cvr.id());
-      }
-      the_cdb.startRound(sorted_deduplicated_new_cvrs.size(),
+          " with " + deduplicated_new_cvrs.size() + " ballots to audit");
+
+      // De-duplicate the CVRs and put them in "pull list" order
+      final List<Long> ballotIdsToAudit =
+          BallotSequencer.sortAndDeduplicateCVRs(
+              new ArrayList<CastVoteRecord>(deduplicated_new_cvrs));
+
+      the_cdb.startRound(ballotIdsToAudit.size(),
                          start_index + new_cvrs.size(),
-                         start_index, ballot_ids_to_audit, new_cvr_ids);
+                         start_index,
+                         ballotIdsToAudit,
+                         new_cvr_ids);
       updateRound(the_cdb, the_cdb.currentRound());
       updateCVRUnderAudit(the_cdb);
       return true;
@@ -523,11 +530,11 @@ public final class ComparisonAuditController {
     } else {
       // use estimates based on current error rate to get length of round
       // we keep doing this until we find a CVR to actually audit
-      final SortedSet<CastVoteRecord> sorted_deduplicated_new_cvrs =
-          new TreeSet<CastVoteRecord>();
+      final Set<CastVoteRecord> deduplicated_new_cvrs =
+          new HashSet<CastVoteRecord>();
       final List<CastVoteRecord> new_cvrs = new ArrayList<>();
       int expected_prefix_length = 0;
-      while (sorted_deduplicated_new_cvrs.isEmpty()) {
+      while (deduplicated_new_cvrs.isEmpty()) {
         expected_prefix_length = computeEstimatedSamplesToAudit(the_cdb);
         if (the_cdb.auditedPrefixLength() < expected_prefix_length) {
           final List<CastVoteRecord> extra_cvrs =
@@ -535,25 +542,23 @@ public final class ComparisonAuditController {
                                      expected_prefix_length - 1);
           new_cvrs.addAll(extra_cvrs);
           Persistence.saveOrUpdate(the_cdb);
-          sorted_deduplicated_new_cvrs.addAll(new_cvrs);
+          deduplicated_new_cvrs.addAll(new_cvrs);
 
           final Set<Long> unique_new_cvr_ids = new HashSet<>();
-          for (final CastVoteRecord cvr : sorted_deduplicated_new_cvrs) {
+          for (final CastVoteRecord cvr : deduplicated_new_cvrs) {
             unique_new_cvr_ids.add(cvr.id());
           }
           for (final Round round : the_cdb.rounds()) {
             for (final Long cvr_id : round.ballotSequence()) {
               if (unique_new_cvr_ids.contains(cvr_id)) {
                 unique_new_cvr_ids.remove(cvr_id);
-                sorted_deduplicated_new_cvrs.remove(Persistence.getByID(cvr_id,
-                                                                        CastVoteRecord.class));
+                deduplicated_new_cvrs.remove(
+                    Persistence.getByID(cvr_id, CastVoteRecord.class));
               }
             }
           }
         }
       }
-
-      final int round_length = sorted_deduplicated_new_cvrs.size();
 
       // the ids of the CVRs to audit, in audit sequence order
       final List<Long> new_cvr_ids = new ArrayList<>();
@@ -561,16 +566,19 @@ public final class ComparisonAuditController {
         new_cvr_ids.add(cvr.id());
       }
 
-      // the ids of the CVRs to audit, deduplicated, in ballot order
-      final List<Long> ballot_ids_to_audit = new ArrayList<>();
-      for (final CastVoteRecord cvr : sorted_deduplicated_new_cvrs) {
-        ballot_ids_to_audit.add(cvr.id());
-      }
+      // De-duplicate the CVRs and put them in "pull list" order
+      final List<Long> ballotIdsToAudit =
+          BallotSequencer.sortAndDeduplicateCVRs(
+              new ArrayList<CastVoteRecord>(deduplicated_new_cvrs));
+
       Main.LOGGER.info("starting audit round " + (rounds.size() + 1) + " for county " +
           the_cdb.id() + " at audit sequence number " + start_index +
-          " with " + round_length + " ballots to audit");
-      the_cdb.startRound(round_length, expected_prefix_length,
-                         start_index, ballot_ids_to_audit, new_cvr_ids);
+          " with " + ballotIdsToAudit.size() + " ballots to audit");
+      the_cdb.startRound(ballotIdsToAudit.size(),
+                         expected_prefix_length,
+                         start_index,
+                         ballotIdsToAudit,
+                         new_cvr_ids);
       updateRound(the_cdb, the_cdb.currentRound());
       updateCVRUnderAudit(the_cdb);
       result = true;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -386,7 +386,7 @@ public final class ComparisonAuditController {
 
       // deduplicate the CVRs and put them in ballot order
       final SortedSet<CastVoteRecord> sorted_deduplicated_cvrs =
-          new TreeSet<CastVoteRecord>(new CastVoteRecord.BallotOrderComparator());
+          new TreeSet<CastVoteRecord>();
       sorted_deduplicated_cvrs.addAll(cvrs_to_audit);
       final List<Long> ballot_ids_to_audit = new ArrayList<Long>();
       for (final CastVoteRecord cvr : sorted_deduplicated_cvrs) {
@@ -438,7 +438,7 @@ public final class ComparisonAuditController {
 
     List<CastVoteRecord> extra_cvrs = new_cvrs;
     final SortedSet<CastVoteRecord> sorted_deduplicated_new_cvrs =
-        new TreeSet<>(new CastVoteRecord.BallotOrderComparator());
+        new TreeSet<CastVoteRecord>();
     sorted_deduplicated_new_cvrs.addAll(new_cvrs);
     while (!extra_cvrs.isEmpty() &&
            sorted_deduplicated_new_cvrs.size() < the_round_length) {
@@ -524,7 +524,7 @@ public final class ComparisonAuditController {
       // use estimates based on current error rate to get length of round
       // we keep doing this until we find a CVR to actually audit
       final SortedSet<CastVoteRecord> sorted_deduplicated_new_cvrs =
-          new TreeSet<>(new CastVoteRecord.BallotOrderComparator());
+          new TreeSet<CastVoteRecord>();
       final List<CastVoteRecord> new_cvrs = new ArrayList<>();
       int expected_prefix_length = 0;
       while (sorted_deduplicated_new_cvrs.isEmpty()) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
@@ -38,7 +38,6 @@ import us.freeandfair.corla.Main;
 import us.freeandfair.corla.controller.BallotSelection;
 import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.json.CVRToAuditResponse;
-import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
@@ -88,8 +87,8 @@ public class CVRToAuditDownload extends AbstractEndpoint {
    * The CSV headers for formatting the response.
    */
   private static final String[] CSV_HEADERS = {
-      "scanner_id", "batch_id", "record_id", "imprinted_id", "ballot_type",
-      "storage_location", "cvr_number", "audited"
+      "storage_location", "scanner_id", "batch_id", "record_id", "imprinted_id",
+      "ballot_type", "cvr_number", "audited"
   };
   
   /**
@@ -236,7 +235,7 @@ public class CVRToAuditDownload extends AbstractEndpoint {
       }
      
       response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
-      response_list.sort(new BallotOrderComparator());
+      response_list.sort(null);
       
       // generate a CSV file from the response list
       the_response.type("text/csv");
@@ -291,9 +290,9 @@ public class CVRToAuditDownload extends AbstractEndpoint {
                                           CSVFormat.DEFAULT.withHeader(CSV_HEADERS).
                                           withQuoteMode(QuoteMode.NON_NUMERIC))) {
       for (final CVRToAuditResponse cvr : the_cvrs) {
-        csvp.printRecord(cvr.scannerID(), cvr.batchID(), cvr.recordID(), cvr.imprintedID(),
-                         cvr.ballotType(), cvr.storageLocation(), cvr.cvrNumber(), 
-                         booleanYesNo(cvr.audited()));
+        csvp.printRecord(cvr.storageLocation(), cvr.scannerID(), cvr.batchID(),
+                         cvr.recordID(), cvr.imprintedID(), cvr.ballotType(),
+                         cvr.cvrNumber(), booleanYesNo(cvr.audited()));
       }
     } 
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -24,7 +24,6 @@ import us.freeandfair.corla.Main;
 import us.freeandfair.corla.controller.BallotSelection;
 import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.json.CVRToAuditResponse;
-import us.freeandfair.corla.json.CVRToAuditResponse.BallotOrderComparator;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
@@ -212,7 +211,7 @@ public class CVRToAuditList extends AbstractEndpoint {
       }
 
       response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
-      response_list.sort(new BallotOrderComparator());
+      response_list.sort(null);
       okJSON(the_response, Main.GSON.toJson(response_list));
     } catch (final PersistenceException e) {
       serverError(the_response, "could not generate cvr list");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetAuditBoardCount.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetAuditBoardCount.java
@@ -11,6 +11,9 @@
 package us.freeandfair.corla.endpoint;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.persistence.PersistenceException;
@@ -24,7 +27,9 @@ import spark.Response;
 import us.freeandfair.corla.Main;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
+import us.freeandfair.corla.model.Round;
 import us.freeandfair.corla.persistence.Persistence;
+import us.freeandfair.corla.util.BallotAssignment;
 
 /**
  * The endpoint for setting the number of audit boards for a given county.
@@ -80,13 +85,48 @@ public class SetAuditBoardCount extends AbstractCountyDashboardEndpoint {
           Persistence.getByID(county.id(), CountyDashboard.class);
 
       if (countyDashboard == null) {
-        Main.LOGGER.error(String.format("could not get county dashboard [id=%d]",
+        Main.LOGGER.error(String.format(
+            "could not get county dashboard [countyId=%d]",
             county.id()));
         serverError(response, "could not set audit board count");
       }
 
-      countyDashboard.setAuditBoardCount(input.get("count"));
+      final Round round = countyDashboard.currentRound();
+
+      if (round == null) {
+        Main.LOGGER.error(String.format(
+            "round not started [countyId=%d]",
+            county.id()));
+        badDataContents(response, "round not started");
+      }
+
+      final Integer ballotCount = round.expectedCount();
+
+      if (ballotCount == null) {
+        Main.LOGGER.error(String.format(
+            "ballot count not yet set for round [countyId=%d, roundNumber=%d]",
+            county.id(),
+            round.number()));
+        badDataContents(response, "ballot count not yet set for round");
+      }
+
+      final Integer auditBoardCount = input.get("count");
+
+      countyDashboard.setAuditBoardCount(auditBoardCount);
+      round.setBallotSequenceAssignment(
+          this.calculateBallotAssignment(auditBoardCount, ballotCount));
+
       Persistence.saveOrUpdate(countyDashboard);
+
+      // TODO: Make sure we don't have to persist the round separately.
+
+      Main.LOGGER.info(String.format(
+          "set the number of audit boards to %d",
+          countyDashboard.auditBoardCount()));
+
+      Main.LOGGER.info(String.format(
+          "set the audit board assignment: %s",
+          round.ballotSequenceAssignment()));
 
       ok(response, String.format("set the number of audit boards to %d",
           countyDashboard.auditBoardCount()));
@@ -107,5 +147,28 @@ public class SetAuditBoardCount extends AbstractCountyDashboardEndpoint {
    */
   private static boolean validateRequestBody(final Map<String, Integer> body) {
     return body.containsKey("count");
+  }
+
+  /**
+   * Calculate the ballot sequence assignment from the given input request.
+   */
+  private static List<Map<String, Integer>>
+      calculateBallotAssignment(final Integer auditBoardCount,
+                                final Integer ballotCount) {
+    final List<Map<String, Integer>> result = new ArrayList<>();
+
+    final List<Integer> boardAssignment =
+        BallotAssignment.assignToBoards(ballotCount, auditBoardCount);
+
+    int index = 0;
+    for (final int count : boardAssignment) {
+      final Map<String, Integer> m = new HashMap<>();
+      m.put("index", index);
+      m.put("count", count);
+      result.add(m);
+      index += count;
+    }
+
+    return result;
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -72,6 +72,11 @@ public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
   protected final String my_storage_location;
 
   /**
+   * The optional audit board index
+   */
+  protected Integer my_audit_board_index;
+
+  /**
    * A flag that indicates whether or not the CVR has been audited.
    */
   protected final boolean my_audited;
@@ -174,6 +179,20 @@ public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
    */
   public String storageLocation() {
     return my_storage_location;
+  }
+
+  /**
+   * @return the audit board index or null if not set
+   */
+  public Integer auditBoardIndex() {
+    return my_audit_board_index;
+  }
+
+  /**
+   * Optionally set the audit board index that will be auditing this ballot.
+   */
+  public void setAuditBoardIndex(final Integer auditBoardIndex) {
+    my_audit_board_index = auditBoardIndex;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -11,9 +11,6 @@
 
 package us.freeandfair.corla.json;
 
-import java.io.Serializable;
-import java.util.Comparator;
-
 import us.freeandfair.corla.util.NaturalOrderComparator;
 import us.freeandfair.corla.util.SuppressFBWarnings;
 
@@ -26,7 +23,7 @@ import us.freeandfair.corla.util.SuppressFBWarnings;
 @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
 @SuppressFBWarnings(value = {"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"},
                     justification = "Field is read by Gson.")
-public class CVRToAuditResponse {
+public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
   /**
    * The (first) audit sequence number.
    */
@@ -185,45 +182,37 @@ public class CVRToAuditResponse {
   }
 
   /**
-   * A comparator to sort CVRLocationResponse objects by scanner ID, then batch ID,
-   * then record ID.
+   * Compares this object to another.
+   *
+   * The sorting happens by the tuple
+   * (storageLocation(), scannerID(), batchID(), recordID()) and will return a
+   * negative, positive, or 0-valued result if this should come before, after,
+   * or at the same point as the other object, respectively.
+   *
+   * @return int
    */
-  @SuppressWarnings("PMD.AtLeastOneConstructor")
-  public static class BallotOrderComparator
-      implements Serializable, Comparator<CVRToAuditResponse> {
-    /**
-     * The serialVersionUID.
-     */
-    private static final long serialVersionUID = 1;
+  @Override
+  public int compareTo(final CVRToAuditResponse other) {
+    final int storageLocation = NaturalOrderComparator.INSTANCE.compare(
+        this.storageLocation(), other.storageLocation());
 
-    /**
-     * Orders two CVRToAuditResponses lexicographically by the triple
-     * (scanner_id, batch_id, record_id).
-     *
-     * @param the_first The first response.
-     * @param the_second The second response.
-     * @return a positive, negative, or 0 value as the first response is
-     * greater than, equal to, or less than the second, respectively.
-     */
-    @SuppressWarnings("PMD.ConfusingTernary")
-    public int compare(final CVRToAuditResponse the_first,
-                       final CVRToAuditResponse the_second) {
-      final int scanner = the_first.my_scanner_id - the_second.my_scanner_id;
-      final int batch = NaturalOrderComparator.INSTANCE.compare(the_first.batchID(),
-                                                             the_second.batchID());
-      final int record = the_first.my_record_id - the_second.my_record_id;
-
-      final int result;
-
-      if (scanner != 0) {
-        result = scanner;
-      } else if (batch != 0) {
-        result = batch;
-      } else {
-        result = record;
-      }
-
-      return result;
+    if (storageLocation != 0) {
+      return storageLocation;
     }
+
+    final int scanner = this.scannerID() - other.scannerID();
+
+    if (scanner != 0) {
+      return scanner;
+    }
+
+    final int batch = NaturalOrderComparator.INSTANCE.compare(
+        this.batchID(), other.batchID());
+
+    if (batch != 0) {
+      return batch;
+    }
+
+    return this.recordID() - other.recordID();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -14,6 +14,8 @@ package us.freeandfair.corla.json;
 import us.freeandfair.corla.util.NaturalOrderComparator;
 import us.freeandfair.corla.util.SuppressFBWarnings;
 
+import static us.freeandfair.corla.util.EqualsHashcodeHelper.*;
+
 /**
  * The standard response provided by the server in response to a request
  * for CVR locations.
@@ -179,6 +181,30 @@ public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
    */
   public boolean audited() {
     return my_audited;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean equals(final Object other) {
+    boolean result = true;
+    if (other instanceof CVRToAuditResponse) {
+      final CVRToAuditResponse otherCtar = (CVRToAuditResponse) other;
+      result &= nullableEquals(this.dbID(), otherCtar.dbID());
+    } else {
+      result = false;
+    }
+
+    return result;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return nullableHashCode(this.dbID());
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CountyDashboardRefreshResponse.java
@@ -155,9 +155,9 @@ public class CountyDashboardRefreshResponse {
   private final Map<AuditSelection, Integer> my_disagreement_count;
 
   /**
-   * The current ballot under audit.
+   * The current ballots under audit, by audit board index.
    */
-  private final Long my_ballot_under_audit_id;
+  private final List<Long> my_ballot_under_audit_ids;
   
   /**
    * The audited prefix length.
@@ -208,7 +208,9 @@ public class CountyDashboardRefreshResponse {
    * mapped by audit reason.
    * @param the_disagreement_count The number of disagreements,
    * mapped by audit reason.
-   * @param the_ballot_under_audit_id The ID of the CVR under audit.
+   * @param the_ballot_under_audit_ids the IDs of the CVRs under audit, in
+   *                                   positions corresponding to the audit
+   *                                   board that should audit it.
    * @param the_audited_prefix_length The length of the audited prefix of the
    * ballots to audit list.
    * @param the_rounds The list of audit rounds.
@@ -242,7 +244,7 @@ public class CountyDashboardRefreshResponse {
                                                the_discrepancy_count,
                                            final Map<AuditSelection, Integer>
                                                the_disagreement_count,
-                                           final Long the_ballot_under_audit_id,
+                                           final List<Long> the_ballot_under_audit_ids,
                                            final Integer the_audited_prefix_length,
                                            final List<Round> the_rounds,
                                            final Round the_current_round,
@@ -267,7 +269,7 @@ public class CountyDashboardRefreshResponse {
     my_audited_ballot_count = the_audited_ballot_count;
     my_discrepancy_count = the_discrepancy_count;
     my_disagreement_count = the_disagreement_count;
-    my_ballot_under_audit_id = the_ballot_under_audit_id;
+    my_ballot_under_audit_ids = the_ballot_under_audit_ids;
     my_audited_prefix_length = the_audited_prefix_length;
     my_rounds = the_rounds;
     my_current_round = the_current_round;
@@ -356,7 +358,7 @@ public class CountyDashboardRefreshResponse {
                                               the_dashboard.ballotsAudited(),
                                               the_dashboard.discrepancies(),
                                               the_dashboard.disagreements(),
-                                              the_dashboard.cvrUnderAudit(),
+                                              the_dashboard.cvrsUnderAudit(),
                                               the_dashboard.auditedPrefixLength(),
                                               rounds,
                                               current_round,

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CVRAuditInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CVRAuditInfo.java
@@ -13,9 +13,7 @@ package us.freeandfair.corla.model;
 
 import static us.freeandfair.corla.util.EqualsHashcodeHelper.nullableEquals;
 
-import java.io.Serializable;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -32,7 +30,6 @@ import javax.persistence.Version;
 
 import us.freeandfair.corla.persistence.AuditReasonSetConverter;
 import us.freeandfair.corla.persistence.PersistentEntity;
-import us.freeandfair.corla.util.NaturalOrderComparator;
 
 /**
  * A class representing a contest to audit or hand count.
@@ -48,7 +45,8 @@ import us.freeandfair.corla.util.NaturalOrderComparator;
 // note: CVRAuditInfo is not serializable because it references CountyDashboard,
 // which is not serializable
 @SuppressWarnings("PMD.ImmutableField")
-public class CVRAuditInfo implements PersistentEntity {
+public class CVRAuditInfo implements Comparable<CVRAuditInfo>,
+                                     PersistentEntity {
   /**
    * The ID number. This is always the same as the CVR ID number.
    */
@@ -296,44 +294,14 @@ public class CVRAuditInfo implements PersistentEntity {
   }
 
   /**
-   * A comparator to sort CVRAuditInfo objects by CVR scanner ID, then batch ID,
-   * then record ID.
+   * Compares this CVRAuditInfo to another.
+   *
+   * Uses the underlying CVR to provide the sorting behavior.
+   *
+   * @return int
    */
-  @SuppressWarnings("PMD.AtLeastOneConstructor")
-  public static class BallotOrderComparator
-      implements Serializable, Comparator<CVRAuditInfo> {
-    /**
-     * The serialVersionUID.
-     */
-    private static final long serialVersionUID = 1;
-
-    /**
-     * Orders two CVRToAuditInfo lexicographically by the triple
-     * (scanner_id, batch_id, record_id).
-     *
-     * @param the_first The first to compare.
-     * @param the_second The second to compare.
-     * @return a positive, negative, or 0 value as the first response is
-     * greater than, equal to, or less than the second, respectively.
-     */
-    @SuppressWarnings("PMD.ConfusingTernary")
-    public int compare(final CVRAuditInfo the_first, final CVRAuditInfo the_second) {
-      final int scanner = the_first.cvr().scannerID() - the_second.cvr().scannerID();
-      final int batch = NaturalOrderComparator.INSTANCE.compare(the_first.cvr().batchID(),
-                                                             the_second.cvr().batchID());
-      final int record = the_first.cvr().recordID() - the_second.cvr().recordID();
-
-      final int result;
-
-      if (scanner != 0) {
-        result = scanner;
-      } else if (batch != 0) {
-        result = batch;
-      } else {
-        result = record;
-      }
-
-      return result;
-    }
+  @Override
+  public int compareTo(final CVRAuditInfo other) {
+    return this.cvr().compareTo(other.cvr());
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CastVoteRecord.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CastVoteRecord.java
@@ -17,7 +17,6 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import javax.persistence.Cacheable;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CastVoteRecord.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CastVoteRecord.java
@@ -70,7 +70,9 @@ import us.freeandfair.corla.util.SuppressFBWarnings;
 // restored when the class is unserialized, because we intentionally made it
 // transient so it wouldn't be. Since that's what "transient" means.
 @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-public class CastVoteRecord implements PersistentEntity, Serializable {
+public class CastVoteRecord implements Comparable<CastVoteRecord>,
+                                       PersistentEntity,
+                                       Serializable {
   /**
    * The serialVersionUID.
    */
@@ -454,44 +456,29 @@ public class CastVoteRecord implements PersistentEntity, Serializable {
   }
 
   /**
-   * A comparator to sort CastVoteRecord objects by scanner ID, then batch ID,
-   * then record ID.
+   * Compares this object to another.
+   *
+   * The sorting happens by the triple (scannerID(), batchID(), recordID()) and
+   * will return a negative, positive, or 0-valued result if this should come
+   * before, after, or at the same point as the other object, respectively.
+   *
+   * @return int
    */
-  @SuppressWarnings("PMD.AtLeastOneConstructor")
-  public static class BallotOrderComparator
-      implements Serializable, Comparator<CastVoteRecord> {
-    /**
-     * The serialVersionUID.
-     */
-    private static final long serialVersionUID = 1;
+  @Override
+  public int compareTo(final CastVoteRecord other) {
+    final int scanner = this.scannerID() - other.scannerID();
 
-    /**
-     * Orders two CastVoteRecord lexicographically by the triple
-     * (scanner_id, batch_id, record_id).
-     *
-     * @param the_first The first CVR.
-     * @param the_second The second CVR.
-     * @return a positive, negative, or 0 value as the first response is
-     * greater than, equal to, or less than the second, respectively.
-     */
-    @SuppressWarnings("PMD.ConfusingTernary")
-    public int compare(final CastVoteRecord the_first, final CastVoteRecord the_second) {
-      final int scanner = the_first.scannerID() - the_second.scannerID();
-      final int batch = NaturalOrderComparator.INSTANCE.compare(the_first.batchID(),
-                                                             the_second.batchID());
-      final int record = the_first.recordID() - the_second.recordID();
-
-      final int result;
-
-      if (scanner != 0) {
-        result = scanner;
-      } else if (batch != 0) {
-        result = batch;
-      } else {
-        result = record;
-      }
-
-      return result;
+    if (scanner != 0) {
+      return scanner;
     }
+
+    final int batch = NaturalOrderComparator.INSTANCE.compare(
+        this.batchID(), other.batchID());
+
+    if (batch != 0) {
+      return batch;
+    }
+
+    return this.recordID() - other.recordID();
   }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -164,6 +164,12 @@ public class CountyDashboard implements PersistentEntity {
   private Instant my_audit_timestamp; 
 
   /**
+   * The number of audit boards.
+   */
+  @Column(name="audit_board_count")
+  private Integer auditBoardCount;
+
+  /**
    * The audit boards.
    */
   @ElementCollection(fetch = FetchType.LAZY)
@@ -172,12 +178,6 @@ public class CountyDashboard implements PersistentEntity {
                    joinColumns = @JoinColumn(name = DASHBOARD_ID, 
                                              referencedColumnName = MY_ID))
   private Map<Integer, AuditBoard> my_audit_boards = new HashMap<>();
-
-  /**
-   * The number of audit boards.
-   */
-  @Column(name="audit_board_count")
-  private Integer auditBoardCount;
 
   /**
    * The audit rounds.
@@ -514,6 +514,7 @@ public class CountyDashboard implements PersistentEntity {
     } else {
       throw new IllegalStateException("cannot start a round while one is running");
     }
+
     // note UI round indexing is from 1, not 0
     final Round round = new Round(my_current_round_index + 1, 
                                   Instant.now(), 
@@ -536,6 +537,8 @@ public class CountyDashboard implements PersistentEntity {
     if (my_current_round_index == null) {
       throw new IllegalStateException("no round to end");
     } else {
+      this.setAuditBoardCount(null);
+
       final Round round = my_rounds.get(my_current_round_index);
       round.setSignatories(the_signatories);
       round.setEndTime(Instant.now());
@@ -628,25 +631,21 @@ public class CountyDashboard implements PersistentEntity {
   }
 
   /**
-   * Returns the CVRs under audit indexed by the audit board to which they are
-   * assigned.
+   * Returns the a list of CVR IDs under audit for the assigned audit boards.
    *
-   * @return A map of audit board indices to the CVR IDs they are assigned.
+   * Delegates the actual calculation to the current Round, if one exists.
+   *
+   * @return a list of CVR IDs assigned to each audit board, where the list
+   *         offset matches the audit board offset.
    */
-  public Long cvrUnderAudit() {
-    throw new UnsupportedOperationException("TODO: Implement this.");
-    /*
-    final Round round = currentRound();
+  public List<Long> cvrsUnderAudit() {
+    final Round round = this.currentRound();
 
-    if (forBoardIndex == null ||
-        round == null ||
-        round.actualCount().compareTo(round.expectedCount()) >= 0) {
+    if (round == null) {
       return null;
     }
 
-    // get the current CVR to audit from the round object
-    return round.ballotSequence().get(round.actualCount());
-    */
+    return round.cvrsUnderAudit();
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -626,22 +626,29 @@ public class CountyDashboard implements PersistentEntity {
   public List<IntermediateAuditReportInfo> intermediateReports() {
     return Collections.unmodifiableList(my_intermediate_reports);
   }
-  
+
   /**
-   * @return the current CVR under audit. This is the first entry in the list 
-   * of CVRs to audit that has no corresponding ACVR. Returns null if there is 
-   * no next CVR to audit.
+   * Returns the CVRs under audit indexed by the audit board to which they are
+   * assigned.
+   *
+   * @return A map of audit board indices to the CVR IDs they are assigned.
    */
   public Long cvrUnderAudit() {
+    throw new UnsupportedOperationException("TODO: Implement this.");
+    /*
     final Round round = currentRound();
-    if (round == null || round.actualCount().compareTo(round.expectedCount()) >= 0) {
+
+    if (forBoardIndex == null ||
+        round == null ||
+        round.actualCount().compareTo(round.expectedCount()) >= 0) {
       return null;
-    } else {
-      // get the current CVR to audit from the round object
-      return round.ballotSequence().get(round.actualCount());
     }
+
+    // get the current CVR to audit from the round object
+    return round.ballotSequence().get(round.actualCount());
+    */
   }
-  
+
   /**
    * @return the number of ballots audited.
    */

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/BallotSequenceAssignmentConverter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/BallotSequenceAssignmentConverter.java
@@ -1,0 +1,68 @@
+/*
+ * Free & Fair Colorado RLA System
+ *
+ * @title ColoradoRLA
+ * @created Aug 26, 2017
+ * @copyright 2017 Colorado Department of State
+ * @license SPDX-License-Identifier: AGPL-3.0-or-later
+ * @creator Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.persistence;
+
+import java.lang.reflect.Type;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * A converter between ballot sequence assignment data and the database.
+ *
+ * @author Democracy Works, Inc. <dev@democracy.works>
+ */
+@Converter
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class BallotSequenceAssignmentConverter
+    implements AttributeConverter<List<Map<String, Integer>>, String> {
+  /**
+   * The required type information.
+   */
+  private static final Type BALLOT_SEQUENCE_ASSIGNMENT_TYPE =
+      new TypeToken<List<Map<String, Integer>>>() { }.getType();
+
+  /**
+   * Our Gson instance, which does not do pretty-printing (unlike the global
+   * one defined in Main).
+   */
+  private static final Gson GSON =
+      new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
+
+  /**
+   * Convert the type into JSON for database storage.
+   *
+   * @param l the list to persist.
+   */
+  @Override
+  public String convertToDatabaseColumn(final List<Map<String, Integer>> l) {
+    return GSON.toJson(l);
+  }
+
+  /**
+   * Converts a type stored as JSON in the database to a Java object.
+   *
+   * @param s the JSON-encoded string
+   */
+  @Override
+  public List<Map<String, Integer>> convertToEntityAttribute(final String s) {
+    return GSON.fromJson(s, BALLOT_SEQUENCE_ASSIGNMENT_TYPE);
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -156,7 +156,7 @@ public class CountyReport {
     for (final Round r : my_rounds) {
       final List<CVRAuditInfo> cvrs_to_audit = 
           ComparisonAuditController.cvrsToAuditInRound(my_cdb, r.number());
-      cvrs_to_audit.sort(new CVRAuditInfo.BallotOrderComparator());
+      cvrs_to_audit.sort(null);
       my_cvrs_to_audit_by_round.put(r.number(), cvrs_to_audit);
     }
     my_dosdb = Persistence.getByID(DoSDashboard.ID, DoSDashboard.class);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/util/BallotAssignment.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/util/BallotAssignment.java
@@ -1,0 +1,68 @@
+/*
+ * Colorado RLA System
+ *
+ * @title ColoradoRLA
+ * @copyright 2018 Colorado Department of State
+ * @license SPDX-License-Identifier: AGPL-3.0-or-later
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utilities for assigning ballots to audit boards.
+ *
+ * @author Democracy Works, Inc. <dev@democracy.works>
+ */
+public final class BallotAssignment {
+  /**
+   * Prevent public construction
+   */
+  private BallotAssignment() {
+  }
+
+  /**
+   * Assign a given number of ballots to a given number of boards.
+   *
+   * Any "extra" ballots that do not divide evenly into the number of boards
+   * will be randomly assigned to a board.
+   *
+   * @param ballots number of ballots to assign
+   * @param boards desired number of boards
+   * @return a list with each element representing a board containing the number
+   *         of ballots to assign that board.
+   */
+  public static List<Integer> assignToBoards(final int ballots,
+                                             final int boards)
+      throws IllegalArgumentException {
+    if (ballots < 0) {
+      throw new IllegalArgumentException("Number of ballots cannot be < 0.");
+    }
+
+    if (boards <= 0) {
+      throw new IllegalArgumentException("Number of boards cannot be <= 0.");
+    }
+
+    // Integer division
+    final int ballotsPerBoard = ballots / boards;
+    final int leftoverBallots = ballots % boards;
+
+    // Assign all boards the even number of ballots
+    final List<Integer> result =
+        new ArrayList<Integer>(Collections.nCopies(boards, ballotsPerBoard));
+
+    // Assign the leftovers
+    for (int i = 0; i < leftoverBallots; i++) {
+      result.set(i, result.get(i) + 1);
+    }
+
+    // Shuffle the results, for fairness!
+    Collections.shuffle(result);
+
+    return result;
+  }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/util/BallotSequencer.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/util/BallotSequencer.java
@@ -1,0 +1,68 @@
+/*
+ * Colorado RLA System
+ *
+ * @title ColoradoRLA
+ * @copyright 2018 Colorado Department of State
+ * @license SPDX-License-Identifier: AGPL-3.0-or-later
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package us.freeandfair.corla.util;
+
+import java.util.List;
+
+import java.util.stream.Collectors;
+
+import us.freeandfair.corla.controller.BallotSelection;
+
+import us.freeandfair.corla.json.CVRToAuditResponse;
+
+import us.freeandfair.corla.model.CastVoteRecord;
+
+/**
+ * Ballot sequencing functionality, such as converting a list of CVRs into
+ * a sorted, deduplicated list of CVRs.
+ *
+ * @author Democracy Works, Inc. <dev@democracy.works>
+ */
+public final class BallotSequencer {
+  /**
+   * Prevent public construction
+   */
+  private BallotSequencer() {
+  }
+
+  /**
+   * Returns sorted, deduplicated list of CVR IDs given a list of CVRs.
+   *
+   * The sort order must match the order of the ballots in the "pull list" that
+   * counties use to fetch ballots. By storing the sorted, deduplicated list of
+   * ballots (CVRs) to audit consistently, we can avoid having to sort them
+   * again and reap other benefits like easier partitioning to support multiple
+   * audit boards.
+   *
+   * @param cvrs input CVRs
+   * @return sorted, deduplicated list of CVR database IDs
+   */
+  public static List<Long>
+      sortAndDeduplicateCVRs(final List<CastVoteRecord> cvrs) {
+    // Deduplicate CVRs.
+    final List<CastVoteRecord> deduplicatedCvrs = cvrs.stream()
+        .distinct()
+        .collect(Collectors.toList());
+
+    // Join with ballot manifest for the purposes of sorting by location, then
+    // sort it.
+    //
+    // TOOD: Abusing the CVRToAuditResponse class for sorting is wrong; we
+    // should reify the "joined CVR / Ballot Manifest" concept.
+    final List<CVRToAuditResponse> sortedAuditResponses =
+        BallotSelection.toResponseList(deduplicatedCvrs);
+    sortedAuditResponses.sort(null);
+
+    // Pull CVR database IDs back out of the now-sorted list.
+    return sortedAuditResponses.stream()
+        .map(auditResponse -> auditResponse.dbID())
+        .collect(Collectors.toList());
+  }
+}

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/model/CastVoteRecordTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/model/CastVoteRecordTest.java
@@ -1,10 +1,12 @@
 package us.freeandfair.corla.model;
 
 import java.time.Instant;
-import java.util.Comparator;
+
 import org.testng.annotations.*;
-import static org.testng.Assert.*;
+
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
+
+import static org.testng.Assert.*;
 
 public class CastVoteRecordTest {
     private CastVoteRecord cvr1;
@@ -12,7 +14,6 @@ public class CastVoteRecordTest {
     private CastVoteRecord cvr3;
     private CastVoteRecord cvr4;
     private Instant now;
-    private Comparator c = new CastVoteRecord.BallotOrderComparator();
 
     @BeforeClass
     public void CastVoteRecordTest() {
@@ -26,8 +27,8 @@ public class CastVoteRecordTest {
 
     @Test()
     public void comparatorTest() {
-        assertEquals(c.compare(cvr1, cvr2), -1);
-        assertEquals(c.compare(cvr2, cvr4), 0);
-        assertEquals(c.compare(cvr3, cvr2), 1);
+        assertEquals(cvr1.compareTo(cvr2), -1);
+        assertEquals(cvr2.compareTo(cvr4), 0);
+        assertEquals(cvr3.compareTo(cvr2), 1);
     }
 }

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/util/BallotAssignmentTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/util/BallotAssignmentTest.java
@@ -28,5 +28,10 @@ public class BallotAssignmentTest {
     final List<Integer> assignment4 = BallotAssignment.assignToBoards(567, 1);
     assertEquals(assignment4.size(), 1);
     assertEquals(Collections.frequency(assignment4, 567), 1);
+
+    final List<Integer> assignment5 = BallotAssignment.assignToBoards(3, 5);
+    assertEquals(assignment5.size(), 5);
+    assertEquals(Collections.frequency(assignment5, 1), 3);
+    assertEquals(Collections.frequency(assignment5, 0), 2);
   }
 }

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/util/BallotAssignmentTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/util/BallotAssignmentTest.java
@@ -1,0 +1,32 @@
+package us.freeandfair.corla.util;
+
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class BallotAssignmentTest {
+  @Test()
+  public void assignToBoardsTest() {
+
+    final List<Integer> assignment1 = BallotAssignment.assignToBoards(36, 4);
+    assertEquals(assignment1.size(), 4);
+    assertEquals(Collections.frequency(assignment1, 9), 4);
+
+    final List<Integer> assignment2 = BallotAssignment.assignToBoards(35, 4);
+    assertEquals(assignment2.size(), 4);
+    assertEquals(Collections.frequency(assignment2, 8), 1);
+    assertEquals(Collections.frequency(assignment2, 9), 3);
+
+    final List<Integer> assignment3 = BallotAssignment.assignToBoards(567, 5);
+    assertEquals(assignment3.size(), 5);
+    assertEquals(Collections.frequency(assignment3, 113), 3);
+    assertEquals(Collections.frequency(assignment3, 114), 2);
+
+    final List<Integer> assignment4 = BallotAssignment.assignToBoards(567, 1);
+    assertEquals(assignment4.size(), 1);
+    assertEquals(Collections.frequency(assignment4, 567), 1);
+  }
+}


### PR DESCRIPTION
**Ballot division:**

At a high level, the existing ballot sequence was left alone, with the audit board division overlaid on top of that sequence. The division only needs to be done once, resulting in an _index_ (the position that audit board is starting from in the full sorted ballot sequence), and a _count_ (the length of that audit board's segment, starting from its _index_) for each audit board.

The algorithm for dividing ballots works as follows:

- Divide the number of ballots to audit evenly across the audit boards, using integer division
- Take the remainder ballots and spread them across the audit boards, in audit board order
- Shuffle the result so the remainder ballots are not always biased toward the first audit boards across rounds.

The end result is a list that looks like `[8, 9, 8, 8]`, whose values are the number of ballots assigned to each board, in board index order.

This information can then be used to generate a list of maps like:

`[{"index": 0, "count": 8}, {"index": 8, "count": 9}, {"index": 17, "count": 8} ...]`

This data structure is saved on the Round, and then further used to determine which CVR is next for a given audit board. That part works by finding the first CVR without a corresponding ACVR (adhering to the sorted ballot order!) for each audit board, and we're off to the races.

In the end, rather than receiving a single CVR ID for the audit board to audit, the client receives a list of them, and depending on which audit board is signed in, that CVR will be chosen for audit.

**Sorting:**

Aside from the behavioral change, there was some decent amount of cleanup possible by making Comparable classes implement Comparable rather than containing their own inner comparator classes.

The sorting should also be slightly faster, since we don't check every attribute on every comparison unless it's needed for the comparison.

**References:**

- https://www.pivotaltracker.com/story/show/160019853