### PR TITLE
Audit phantom ballots before round start and properly sort ballots

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -178,24 +178,6 @@ public final class ComparisonAuditController {
                                    final List<Long> ballotSequence) {
     LOGGER.info(String.format("Starting a round for %s, drivingContests=%s",
                               cdb.county(), cdb.drivingContestNames()));
-    // FIXME resolve Gorddon's stuff
-    //   // the list of CVRs to audit, in audit sequence order
-    //   final List<CastVoteRecord> cvrs_to_audit =
-    //       PhantomBallots.auditPhantomRecords(
-    //           the_cdb,
-    //           getCVRsInAuditSequence(the_cdb.county(), 0, to_audit - 1));
-
-    //   // the IDs of the CVRs to audit, in audit sequence order
-    //   final List<Long> audit_subsequence_ids = new ArrayList<Long>();
-    //   for (final CastVoteRecord cvr : cvrs_to_audit) {
-    //     audit_subsequence_ids.add(cvr.id());
-    //   }
-
-    //   // Remove phantom CVRs, de-duplicate CVRs and put them in "pull list"
-    //   // order
-    //   final List<Long> ballotIdsToAudit =
-    //       BallotSequencer.sortAndDeduplicateCVRs(
-    //           PhantomBallots.removePhantomRecords(cvrs_to_audit));
     cdb.startRound(ballotSequence.size(), auditSequence.size(),
                    0, ballotSequence, auditSequence);
     // FIXME it appears these two must happen in this order.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ContestResult.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ContestResult.java
@@ -30,7 +30,6 @@ import javax.persistence.ManyToMany;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 import javax.persistence.Version;
 
@@ -40,7 +39,6 @@ import org.apache.log4j.Logger;
 import us.freeandfair.corla.persistence.LongListConverter;
 import us.freeandfair.corla.persistence.PersistentEntity;
 import us.freeandfair.corla.persistence.StringSetConverter;
-import us.freeandfair.corla.controller.BallotSelection.Selection;
 
 /**
  * A class representing the results for a contest across counties.

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/controllers/BallotSelectionTest.java
@@ -98,7 +98,7 @@ public class BallotSelectionTest {
     List<Segment> segments = new ArrayList<>();
     segments.add(new Segment());
     Segment result = BallotSelection.Selection.combineSegments(segments);
-    assertEquals(new ArrayList<>(), result.ballotSequence());
+    assertEquals(new ArrayList<>(), result.cvrsInBallotSequence());
   }
 
   @Test()
@@ -124,7 +124,12 @@ public class BallotSelectionTest {
     List<Long> expectedBallotSequence = Stream.of(1L, 2L, 3L, 4L).collect(Collectors.toList());
     Segment result = BallotSelection.Selection.combineSegments(segments);
     assertEquals(result.auditSequence(), expectedAuditSequence);
-    assertEquals(result.ballotSequence(), expectedBallotSequence);
+    assertEquals(
+        result.cvrsInBallotSequence()
+            .stream()
+            .map(cvr -> cvr.id())
+            .collect(Collectors.toList()),
+        expectedBallotSequence);
   }
 
   // @Test()


### PR DESCRIPTION
Sorry for changing the Segment class, I couldn't figure out a cleaner way to integrate this.

The assumptions made about the order of CVRs was mistaken - CDOS wanted ballots sorted by storage bin, which necessitates joining to the ballot manifest one way or another. I had already had code to do this which I'm able to reuse.

The CVRs stored in `Segment` are intentionally unordered now (but continue to be in a Set) so that nobody assumes ordering. The final ordering is set when StartAuditRound is called. We also return the CVRs directly from the Segment, because we also have to audit phantom ballots (on behalf of the given dashboard) when the round starts, if any were pulled during selection.