### PR TITLE
Don't try to handle ties in a County context

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRExportImport.java
@@ -614,4 +614,5 @@ public class CVRExportImport extends AbstractCountyDashboardEndpoint {
       }
       return result;
     }
+  }
 }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
@@ -248,6 +248,8 @@ public class StartAuditRound extends AbstractDoSDashboardEndpoint {
    * happens
    */
   public List<ContestResult> countAndSaveContests(final Set<ContestToAudit> cta) {
+    LOGGER.debug(String.format("[countAndSaveContests: cta=%s]", cta));
+
     return
       ContestCounter.countAllContests().stream()
       .map(cr -> {cr.setAuditReason(targetedContestReasons(cta)

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/DoSDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/DoSDashboard.java
@@ -264,16 +264,6 @@ public class DoSDashboard implements PersistentEntity, Serializable {
   }
 
   /**
-   * data access helper
-   * @return contests of contestsToAudit a.k.a selected contests, targeted contests
-   */
-  // FIXME this might not be needed.
-  public Stream<String> targetedContestNames() {
-    return contestsToAudit().stream()
-      .map(a -> a.contest().name());
-  }
-
-  /**
    * @return a String representation of this contest.
    */
   @Override


### PR DESCRIPTION
Now that we have contests spanning counties, we need to wait until all possible CVR exports have been uploaded before we can count the results and look for any ties.

By doing it at the time of CVR import, a contest that might have tied in a county - but not overall - gets placed in the DoSDashboards.contestsToAudit() when it has no business being there yet.