### PR TITLE
fix: crtest audit board sign-in with extra rounds

### DIFF
--- a/test/e-state-county/audit.bash
+++ b/test/e-state-county/audit.bash
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-# automate auditing of 3 contests in 3 counties
+# Automate auditing of 3 contests in 3 counties
+
+# Run from test/smoketest
+
 # Output goes in $LOGDIR (/tmp by default, created if necessary) in files and export directories
 # tagged by $LOGTAG (default "state-county")
 
@@ -16,11 +19,11 @@ mkdir -p $LOGDIR
     echo -e "\nStart 'Define audit' step and upload county audit data\n"
     ./main.py dos_init
 
-    ./main.py -c 1 -f ../e-state-county/cvr-1000--20-200.csv -F ../e-state/manifest-1-1000.csv county_setup
-    ./main.py -c 2 -f ../e-state-county/cvr-10--0--2-4-1.csv -F ../e-state/manifest-2-10.csv county_setup
+    ./main.py -c 1 -f ../e-state-county/cvr-1000--20-200.csv -F ../e-state-county/manifest-1-1000.csv county_setup
+    ./main.py -c 2 -f ../e-state-county/cvr-10--0--2-4-1.csv -F ../e-state-county/manifest-2-10.csv county_setup
     # Alternative, without a tie in just the county 2 portion of Prop 1
-    # ./main.py -c 2 -f ../e-state-county/cvr-10--1--2-4-1.csv -F ../e-state/manifest-2-10.csv county_setup
-     ./main.py -c 3 -f ../e-state-county/cvr-100--2-24-40.csv -F ../e-state/manifest-3-100.csv county_setup
+    # ./main.py -c 2 -f ../e-state-county/cvr-10--1--2-4-1.csv -F ../e-state-county/manifest-2-10.csv county_setup
+     ./main.py -c 3 -f ../e-state-county/cvr-100--2-24-40.csv -F ../e-state-county/manifest-3-100.csv county_setup
 
     echo -e "\nFinish 'Define audit' step to select contests, enter the random seed, and Launch the Audit\n"
 

--- a/test/smoketest/main.py
+++ b/test/smoketest/main.py
@@ -724,11 +724,8 @@ def county_audit(ac, county_id):
     # This one currently doesn't actually include 'political_party', but this still seems to work
     sign_off_request = {'index': 0, 'audit_board': audit_board_set}
 
-    r = test_endpoint_get(ac, county_s, "/audit-board-asm-state")
-    if ((r.json()['current_state'] == "WAITING_FOR_ROUND_START_NO_AUDIT_BOARD") or
-        (r.json()['current_state'] == "ROUND_IN_PROGRESS_NO_AUDIT_BOARD")):
-        r = test_endpoint_json(ac, county_s, "/set-audit-board-count", audit_board_count_request)
-        r = test_endpoint_json(ac, county_s, "/audit-board-sign-in", sign_in_request)
+    r = test_endpoint_json(ac, county_s, "/set-audit-board-count", audit_board_count_request)
+    r = test_endpoint_json(ac, county_s, "/audit-board-sign-in", sign_in_request)
 
     # Print this tool's notion of what should be audited, based on seed etc.
     # for auditing the audit.
@@ -762,15 +759,6 @@ def county_audit(ac, county_id):
             for contest_id, d in contest_discrepancies.iteritems():
                 discrepancies += "%s %2d %2d %2d %2d %2d  " % (contest_id, d["2"], d["1"], d["0"], d["-1"], d["-2"])
             print(discrepancies)
-
-        # Simulate checking out and in on the 5th upload out of every 50 in each round.  TODO - should we drop this?
-        if i % 50 == 5:
-            r = test_endpoint_json(ac, county_s, "/sign-off-audit-round", sign_off_request)
-            r = test_endpoint_get(ac, county_s, "/audit-board-asm-state")
-            # print(r.text)
-            r = test_endpoint_json(ac, county_s, "/audit-board-sign-in", sign_in_request)
-            r = test_endpoint_get(ac, county_s, "/audit-board-asm-state")
-            # print(r.text)
 
         total_audited = county_dashboard['audited_ballot_count']
 


### PR DESCRIPTION
Fix logic around when to sign-in (and /set-audit-board-count)
to make sure it happens each round.

And drop old periodic /sign-off-audit-round from days when that was
a way to go to lunch or get an interrim periodic report