### PR TITLE
A CVR counts as an audited sample if it was selected for an audit

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -360,8 +360,9 @@ public final class BallotSelection {
         segment.addCvrs(cvrs);
         segment.addCvrIds(cvrs); // keep raw data separate
       });
-    LOGGER.info("resolveSelection = " + selection.segments);
-    LOGGER.info("resolveSelection = " + Selection.combineSegments(selection.allSegments()).cvrIds);
+    LOGGER.debug(String.format("[resolveSelection: selection=%s, combinedSegments=%s]",
+                               selection.segments,
+                               Selection.combineSegments(selection.allSegments()).cvrIds));
     return selection;
   }
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -412,7 +412,7 @@ public final class ComparisonAuditController {
         disagreements.add(ca.auditReason());
       }
 
-      ca.signalSampleAudited(audit_count);
+      ca.signalSampleAudited(audit_count, cvr_under_audit.id());
       Persistence.saveOrUpdate(ca);
     }
 
@@ -468,7 +468,7 @@ public final class ComparisonAuditController {
         }
         disagreements.add(ca.auditReason());
       }
-      ca.signalSampleUnaudited(result);
+      ca.signalSampleUnaudited(result, cvr_under_audit.id());
       Persistence.saveOrUpdate(ca);
     }
 


### PR DESCRIPTION
Given a CVR ID, we should be able to tell whether we should mark it for a given `ComparisonAudit` like this: 
```java
final boolean covered = isCovering(cvrID);
final boolean targeted = contestResult().getAuditReason().isTargeted();
```
This would mean contests being audited for opportunistic benefits should have an audited sample count of 0. [Related to this bug](https://www.pivotaltracker.com/story/show/160826772) 