### PR TITLE
Move "next card" button on the review screen

### DIFF
--- a/client/screen.css
+++ b/client/screen.css
@@ -224,6 +224,10 @@ th.rla-county-contest-info {
     align-items: center;
 }
 
+.button-container-left {
+    justify-content: flex-start;
+}
+
 .not-found-header {
     font-size: 18px;
     margin-bottom: 20px;

--- a/client/src/component/County/Audit/Wizard/ReviewStage.tsx
+++ b/client/src/component/County/Audit/Wizard/ReviewStage.tsx
@@ -224,7 +224,7 @@ const ReviewStage = (props: ReviewStageProps) => {
                             page.
                         </p>
                         <BallotReview countyState={ countyState } marks={ marks } back={ prevStage } />
-                        <div className='button-container'>
+                        <div className='button-container button-container-left'>
                           <button className='pt-large pt-button pt-intent-success pt-breadcrumb' onClick={ onClick }>
                               Submit & Next Ballot Card
                           </button>


### PR DESCRIPTION
Avoids misclicks if people click twice on the first button.

**References:**

[Pivotal card](https://www.pivotaltracker.com/story/show/160827012)