### PR TITLE
When a county runs out of ballots, we can only terminate single county audits

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMTransitionFunction.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMTransitionFunction.java
@@ -207,6 +207,7 @@ public interface ASMTransitionFunction {
     O(new ASMTransition(ROUND_IN_PROGRESS,
                         ROUND_COMPLETE_EVENT,
                         WAITING_FOR_ROUND_SIGN_OFF)),
+
     // this can happen if there are no ballots to audit in the first round
     O1(new ASMTransition(AUDIT_INITIAL_STATE,
                         ROUND_COMPLETE_EVENT,
@@ -216,6 +217,12 @@ public interface ASMTransitionFunction {
     O2(new ASMTransition(WAITING_FOR_ROUND_START,
                          ROUND_COMPLETE_EVENT,
                          WAITING_FOR_ROUND_START)),
+
+    // this can happen if there are no ballots for an audit board
+    O3(new ASMTransition(WAITING_FOR_ROUND_START,
+                         ROUND_SIGN_OFF_EVENT,
+                         WAITING_FOR_ROUND_START)),
+
 
     /* We probably want this transition eventually, but not for CDOS
     EARLY(new ASMTransition(ROUND_IN_PROGRESS,

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -262,6 +262,13 @@ public final class BallotSelection {
                                           final String seed,
                                           final Integer minIndex,
                                           final Integer maxIndex) {
+    if (minIndex > maxIndex) {
+      // you are done, silly
+      Selection selection = new Selection();
+      selection.contestResult = contestResult;
+      return selection;
+    }
+
     final int domainSize = ballotsCast(contestResult.countyIDs()).intValue();
     final PseudoRandomNumberGenerator gen =
       new PseudoRandomNumberGenerator(seed, true, 1, domainSize);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -150,10 +150,9 @@ public final class BallotSelection {
      * a good idea
      */
     public String toString() {
-      return String.format("[Segment auditSequence=%s ballotPositions=%s cvrs=%s]",
+      return String.format("[Segment auditSequence=%s ballotPositions=%s]",
                            auditSequence(),
-                           tributes.stream().map(t -> t.ballotPosition).collect(Collectors.toList()),
-                           this.cvrs);
+                           tributes.stream().map(t -> t.ballotPosition).collect(Collectors.toList()));
     }
   }
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -264,7 +264,7 @@ public final class BallotSelection {
                                           final Integer maxIndex) {
     if (minIndex > maxIndex) {
       // you are done, silly
-      Selection selection = new Selection();
+      final Selection selection = new Selection();
       selection.contestResult = contestResult;
       return selection;
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -360,8 +360,9 @@ public final class BallotSelection {
         segment.addCvrs(cvrs);
         segment.addCvrIds(cvrs); // keep raw data separate
       });
-    LOGGER.info("resolveSelection = " + selection.segments);
-    LOGGER.info("resolveSelection = " + Selection.combineSegments(selection.allSegments()).cvrIds);
+    LOGGER.debug(String.format("[resolveSelection: selection=%s, combinedSegments=%s]",
+                               selection.segments,
+                               Selection.combineSegments(selection.allSegments()).cvrIds));
     return selection;
   }
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -216,7 +216,7 @@ public final class ComparisonAuditController {
                   cdb.id() + ", cvr " +
                   the_cvr_under_audit.id() + " not under audit");
     } else if (checkACVRSanity(the_cvr_under_audit, the_audit_cvr)) {
-      LOGGER.debug("[submitAuditCVR: ACVR seems sane]");
+      LOGGER.trace("[submitAuditCVR: ACVR seems sane]");
       // if the record is the current CVR under audit, or if it hasn't been
       // audited yet, we can just process it
       if (info.acvr() == null) {
@@ -224,14 +224,14 @@ public final class ComparisonAuditController {
         // they might be out of order, but that's OK because we have strong
         // requirements about finishing rounds before looking at results as
         // final and valid
-        LOGGER.debug("[submitAuditCVR: ACVR is null, creating]");
+        LOGGER.trace("[submitAuditCVR: ACVR is null, creating]");
         info.setACVR(the_audit_cvr);
         final int new_count = audit(cdb, info, true);
         cdb.addAuditedBallot();
         cdb.setAuditedSampleCount(cdb.auditedSampleCount() + new_count);
       } else {
         // the record has been audited before, so we need to "unaudit" it
-        LOGGER.debug("[submitAuditCVR: ACVR is seen, un/reauditing]");
+        LOGGER.trace("[submitAuditCVR: ACVR is seen, un/reauditing]");
         final int former_count = unaudit(cdb, info);
         info.setACVR(the_audit_cvr);
         final int new_count = audit(cdb, info, true);
@@ -239,7 +239,7 @@ public final class ComparisonAuditController {
       }
       result = true;
     }  else {
-      LOGGER.info("attempt to submit non-corresponding ACVR " +
+      LOGGER.warn("attempt to submit non-corresponding ACVR " +
                   the_audit_cvr.id() + " for county " + cdb.id() +
                   ", cvr " + the_cvr_under_audit.id());
     }
@@ -269,10 +269,6 @@ public final class ComparisonAuditController {
   public static int estimatedSamplesToAudit(final CountyDashboard cdb) {
     int to_audit = Integer.MIN_VALUE;
     final Set<String> drivingContests = cdb.drivingContestNames();
-
-    LOGGER.debug(String.format("[estimatedSamplesToAudit: "
-                               + "drivingContestNames=%s, comparisonAudits=%s]",
-                               cdb.drivingContestNames(), cdb.comparisonAudits()));
 
     // FIXME might look better as a stream().filter().
     for (final ComparisonAudit ca : cdb.comparisonAudits()) { // to_audit = cdb.comparisonAudits.stream()

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -412,7 +412,7 @@ public final class ComparisonAuditController {
         disagreements.add(ca.auditReason());
       }
 
-      ca.signalSampleAudited(audit_count);
+      ca.signalSampleAudited(audit_count, cvr_under_audit.id());
       Persistence.saveOrUpdate(ca);
     }
 
@@ -468,7 +468,7 @@ public final class ComparisonAuditController {
         }
         disagreements.add(ca.auditReason());
       }
-      ca.signalSampleUnaudited(result);
+      ca.signalSampleUnaudited(result, cvr_under_audit.id());
       Persistence.saveOrUpdate(ca);
     }
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
@@ -189,7 +189,7 @@ public class SignOffAuditRound extends AbstractAuditBoardDashboardEndpoint {
           ASMUtilities.asmFor(AuditBoardDashboardASM.class,
                               String.valueOf(cdb.id()));
 
-       if (null != asm && asm.currentState() == ROUND_IN_PROGRESS) {
+        if (null != asm && asm.currentState() == ROUND_IN_PROGRESS) {
           ASMUtilities.step(ROUND_COMPLETE_EVENT,
                             AuditBoardDashboardASM.class,
                             String.valueOf(cdb.id()));
@@ -210,12 +210,16 @@ public class SignOffAuditRound extends AbstractAuditBoardDashboardEndpoint {
 
           if (cdb.allAuditsComplete()) {
             my_event.set(RISK_LIMIT_ACHIEVED_EVENT);
+            // In this case, we'd be terminating single county audits
+            // for opportunistic benefits only.
             final List<ComparisonAudit> terminated = cdb.endSingleCountyAudits();
             LOGGER.debug(String.format("[signoff: all targeted audits finished in %s County."
                                        + " Terminated these audits: %s]",
                                        cdb.county().name(), terminated));
             auditComplete = true;
           } else if (cdb.cvrsImported() <= cdb.ballotsAudited()) {
+            // In this case, we'd be terminating targeted and
+            // opportunistic single county audits.
             final List<ComparisonAudit> terminated = cdb.endSingleCountyAudits();
             auditComplete = cdb.allAuditsComplete();
             LOGGER.debug(String.format("[signoff: no more ballots; terminated single-county audits"

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.persistence.Cacheable;
 import javax.persistence.CollectionTable;
@@ -357,6 +359,14 @@ public class ComparisonAudit implements PersistentEntity {
       .filter(c -> c.id().equals(countyId))
       .findFirst()
       .isPresent();
+  }
+
+  /**
+   * Does this audit belong to only a single county?
+   */
+  public boolean isSingleCountyFor(final County c) {
+    return getCounties().equals(Stream.of(c)
+                                .collect(Collectors.toSet()));
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
@@ -566,8 +566,8 @@ public class ComparisonAudit implements PersistentEntity {
 
     if (targeted && !covered) {
       LOGGER.debug
-        (String.format("[signalSampleAudited: Targeted contest, but cvrID (%d) not selected.]",
-                       cvrID));
+        (String.format("[signalSampleAudited: %s is targeted, but cvrID (%d) not selected for audit.]",
+                       contestResult().getContestName(), cvrID));
     }
 
     if (targeted && covered) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Comparator;
+import java.util.stream.Collectors;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
@@ -955,11 +956,26 @@ public class CountyDashboard implements PersistentEntity {
   /**
    * Ends all audits in the county. This changes the status of any audits
    * that have not achieved their risk limit to ENDED.
+   *
+   * You should not use this lightly, some of the audits might be shared
+   * with others!
    */
   public void endAudits() {
     for (final ComparisonAudit ca : audits) {
       ca.endAudit();
     }
+  }
+
+  /**
+   * End all audits that only belong to this county.
+   */
+  public List<ComparisonAudit> endSingleCountyAudits() {
+    return comparisonAudits().stream()
+      .filter(a -> a.isSingleCountyFor(this.county()))
+      .map(a -> {
+          a.endAudit();
+          return a;})
+      .collect(Collectors.toList());
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/Round.java
@@ -333,10 +333,15 @@ public class Round implements Serializable {
     final List<Map<String, Integer>> bsa = this.ballotSequenceAssignment();
 
     if (bsa == null) {
-      return null;
+      return new ArrayList<>();
     }
 
     final List<Long> bs = this.ballotSequence();
+
+    if (bs.isEmpty()) {
+      // avoid psql exception
+      return new ArrayList<>();
+    }
 
     // All CVR IDs that have no corresponding ACVR
     final Session s = Persistence.currentSession();

--- a/test/e-state-county/audit.bash
+++ b/test/e-state-county/audit.bash
@@ -17,17 +17,15 @@ mkdir -p $LOGDIR
     ./main.py reset
 
     echo -e "\nStart 'Define audit' step and upload county audit data\n"
-    ./main.py dos_init
+    ./main.py dos_init -s 12341234123412341234 -r 0.05
 
     ./main.py -c 1 -f ../e-state-county/cvr-1000--20-200.csv -F ../e-state-county/manifest-1-1000.csv county_setup
     ./main.py -c 2 -f ../e-state-county/cvr-10--0--2-4-1.csv -F ../e-state-county/manifest-2-10.csv county_setup
-    # Alternative, without a tie in just the county 2 portion of Prop 1
-    # ./main.py -c 2 -f ../e-state-county/cvr-10--1--2-4-1.csv -F ../e-state-county/manifest-2-10.csv county_setup
-     ./main.py -c 3 -f ../e-state-county/cvr-100--2-24-40.csv -F ../e-state-county/manifest-3-100.csv county_setup
+    ./main.py -c 3 -f ../e-state-county/cvr-100--2-24-40.csv -F ../e-state-county/manifest-3-100.csv county_setup
 
     echo -e "\nFinish 'Define audit' step to select contests, enter the random seed, and Launch the Audit\n"
 
-    ./main.py -C 1  -C 3 -C 4 -C 5  -C 7 -C 8 dos_start
+    ./main.py -C 0 -C 1 -C 4 -C 5 dos_start
 
 ) | tee $LOGDIR/$LOGTAG.sm
 
@@ -43,7 +41,9 @@ rla_export -e $LOGDIR/$LOGTAG-setup.export
 
 rla_export -e $LOGDIR/$LOGTAG-round1.export
 
-# Final round, no discrepancies
+echo -e "\nPress <C-c> if you don't want to start a second round! Otherwise, press <RET> when ready...\n"
+read
+# Second round, no discrepancies
 (
     echo -e "\nRun second round\n"
 

--- a/test/e-state-county/audit.bash
+++ b/test/e-state-county/audit.bash
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# Automate auditing of 3 contests in 3 counties
+# Automate auditing of 3 contests in 3 counties. 3 discrepancies in
+# Adams move to a second round; no further discrepancies allow risk
+# limit to be achieved.
 
 # Run from test/smoketest
 
@@ -17,7 +19,7 @@ mkdir -p $LOGDIR
     ./main.py reset
 
     echo -e "\nStart 'Define audit' step and upload county audit data\n"
-    ./main.py dos_init -s 12341234123412341234 -r 0.05
+    ./main.py dos_init -r 0.05
 
     ./main.py -c 1 -f ../e-state-county/cvr-1000--20-200.csv -F ../e-state-county/manifest-1-1000.csv county_setup
     ./main.py -c 2 -f ../e-state-county/cvr-10--0--2-4-1.csv -F ../e-state-county/manifest-2-10.csv county_setup
@@ -25,7 +27,7 @@ mkdir -p $LOGDIR
 
     echo -e "\nFinish 'Define audit' step to select contests, enter the random seed, and Launch the Audit\n"
 
-    ./main.py -C 0 -C 1 -C 4 -C 5 dos_start
+    ./main.py -C 0 -C 1 -C 4 -C 5 -s 12341234123412341234 dos_start
 
 ) | tee $LOGDIR/$LOGTAG.sm
 


### PR DESCRIPTION
If County A and County B were both participating in some multi-county `Contest One` and County B had a second single-county `Contest Two`, the simple act of running out of ballots to audit in County B (low voter turnout?) would try to end all of County B's audits. That's fine for `Contest Two`, but if we end `Contest One`, then we'll never be able to achieve a risk limit and complete as hoped.

You can see this for yourself if you use `test/e-state-county/audit.bash`. I've fiddled with it so it's a little cleaner in the UI. That'll run an audit for each of the four contests. Two contests, `Prop 1` and `Prop 2` include all three counties, one contest, `Prop 3`, occurs in Alamosa and Arapaho, and the last, `Prop 4`, is only in Alamosa.