### PR TITLE
[phantom-record] add ballotType to State report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with the following tags indicating the components affected:
   as the RLA export.
 
 ## 2.0.2-SNAPSHOT - In development
+- [API - (phantom-record) add ballotType to State report][pr68]
 
 ## 2.0.1 - Bugfix release
 
@@ -112,3 +113,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr62]: https://github.com/democracyworks/ColoradoRLA/pull/62
 [pr63]: https://github.com/democracyworks/ColoradoRLA/pull/63
 [pr64]: https://github.com/democracyworks/ColoradoRLA/pull/64
+[pr68]: https://github.com/democracyworks/ColoradoRLA/pull/68

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/StateReport.java
@@ -693,6 +693,10 @@ public class StateReport {
         cell.setCellType(CellType.STRING);
         cell.setCellStyle(bold_right_style);
         cell.setCellValue("Disagreement");
+        cell = row.createCell(cell_number++);
+        cell.setCellType(CellType.STRING);
+        cell.setCellStyle(bold_right_style);
+        cell.setCellValue("Ballot Type");
 
         max_cell_number = Math.max(max_cell_number, cell_number);
         for (final CVRAuditInfo audit_info : 
@@ -720,6 +724,11 @@ public class StateReport {
           cell.setCellType(CellType.STRING);
           cell.setCellStyle(standard_right_style);
           cell.setCellValue(booleanYesNo(!audit_info.disagreement().isEmpty()));
+          cell = row.createCell(cell_number++);
+          cell.setCellType(CellType.STRING);
+          cell.setCellStyle(standard_right_style);
+          cell.setCellValue(audit_info.cvr().ballotType());
+
         }
       }
       for (int i = 0; i < max_cell_number; i++) {


### PR DESCRIPTION
This is the simplest way I could come up with, plus, ballot type might be interesting because along with the imprinted-id it is one of the things the auditors are supposed to check.