### PR TITLE
Only counts selections for the contest we care about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ with the following tags indicating the components affected:
 - `TOOLING` refers to changes to tooling that falls outside the UI or API, such
   as the RLA export.
 
-## 2.0.3 - SNAPSHOT - In development
+## 2.0.3 - Bugfix release
+- [API - Only counts selections for the contest we care about][pr70]
 
 ## 2.0.2 - Bugfix release
 
@@ -119,3 +120,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr64]: https://github.com/democracyworks/ColoradoRLA/pull/64
 [pr66]: https://github.com/democracyworks/ColoradoRLA/pull/66
 [pr68]: https://github.com/democracyworks/ColoradoRLA/pull/68
+[pr70]: https://github.com/democracyworks/ColoradoRLA/pull/70

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "corla-client",
-  "version": "2.0.3-SNAPSHOT",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "corla-client",
-    "version": "2.0.3-SNAPSHOT",
+    "version": "2.0.3",
     "description": "Browser-based client to facilitate risk-limiting audits for the State of Colorado.",
     "main": "index.js",
     "scripts": {

--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>us.freeandfair.production</groupId>
 	<artifactId>corla-server</artifactId>
-	<version>2.0.3-SNAPSHOT</version>
+	<version>2.0.3</version>
 	<name>ColoradoRLA</name>
 	<description>A risk-limiting audit system for the State of Colorado</description>
 	<properties>

--- a/server/eclipse-project/project_configuration/freeandfair_pmd_ruleset.xml
+++ b/server/eclipse-project/project_configuration/freeandfair_pmd_ruleset.xml
@@ -14,6 +14,7 @@ The Free &amp; Fair ruleset checks Java code for possible issues.
   <rule ref="rulesets/java/codesize.xml"/>
   <rule ref="rulesets/java/comments.xml"/>
   <rule ref="rulesets/java/controversial.xml">
+    <exclude name="AtLeastOneConstructor"/>
     <exclude name="AvoidFinalLocalVariable"/>
     <exclude name="DataflowAnomalyAnalysis"/>
     <exclude name="OnlyOneReturn"/>

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
@@ -656,6 +656,13 @@ public class ComparisonAudit implements PersistentEntity {
     return contestResult().getContestCVRIds().contains(cvrId);
   }
 
+  /** calculate the number of times the given cvrId appears in the selection
+   * (across all rounds)
+   **/
+  public int multiplicity(final Long cvrId) {
+    return Collections.frequency(contestResult().getContestCVRIds(), cvrId);
+  }
+
   /**
    * Records the specified discrepancy. If the discrepancy is for this Contest
    * but from a CVR/ballot that was not selected for this Contest (selected for

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/LongIntegerMapConverter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/LongIntegerMapConverter.java
@@ -1,0 +1,54 @@
+package us.freeandfair.corla.persistence;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * A converter between maps from longs to integers and JSON
+ * representations of those maps, for database efficiency.
+ *
+ */
+@Converter
+public class LongIntegerMapConverter
+  implements AttributeConverter<Map<Long, Integer>, String> {
+
+  /**
+   * The type information for a map.
+   */
+  private static final Type LONG_INTEGER_MAP =
+    new TypeToken<Map<Long, Integer>>() { }.getType();
+
+  /**
+   * Our Gson instance, which does not do pretty-printing (unlike the global
+   * one defined in Main).
+   */
+  private static final Gson GSON =
+    new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
+
+  /**
+   * Converts the specified list of Strings to a database column entry.
+   *
+   * @param the_set The list of Strings.
+   */
+  @Override
+  public String convertToDatabaseColumn(final Map<Long, Integer> the_map) {
+    return GSON.toJson(the_map);
+  }
+
+  /**
+   * Converts the specified database column entry to a list of strings.
+   *
+   * @param the_column The column entry.
+   */
+  @Override
+  public Map<Long, Integer> convertToEntityAttribute(final String the_column) {
+    return GSON.fromJson(the_column, LONG_INTEGER_MAP);
+  }
+}

--- a/test/2.0-test-data/audit.bash
+++ b/test/2.0-test-data/audit.bash
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Automate auditing of 4 contests in 3 counties. This is using the seed
+# and risk limit that we've been hand-testing this data set with.
+
+# Run from test/smoketest
+
+# Output goes in $LOGDIR (/tmp by default, created if necessary) in files and export directories
+# tagged by $LOGTAG (default "2-point-oh")
+
+LOGDIR=${LOGDIR:-/tmp}
+LOGTAG=${LOGTAG:-2-point-oh}
+
+mkdir -p $LOGDIR
+
+(
+    # try skipping this also
+    ./main.py reset
+
+    echo -e "\nStart 'Define audit' step and upload county audit data\n"
+    ./main.py dos_init -r 0.10
+
+    ./main.py -c 1 -f ../2.0-test-data/adams-cvrexport.csv -F ../2.0-test-data/adams-manifest.csv county_setup
+    ./main.py -c 2 -f ../2.0-test-data/alamosa-cvrexport.csv -F ../2.0-test-data/alamosa-manifest.csv county_setup
+
+    echo -e "\nStatewide Regent and Alamosa County Commissioner targeted at 10% and started!\n"
+    ./main.py -C 0 -C 3 -s 12341234123412341234 dos_start
+) | tee $LOGDIR/$LOGTAG.sm
+
+
+echo -e "Press <RET> when ready to audit..."
+read
+
+rla_export -e $LOGDIR/$LOGTAG-setup.export
+
+(
+    echo -e "\nRun first round, no discrepancies \n"
+
+    ./main.py -c 1 -p '-1 100' -R 1 county_audit
+    ./main.py -c 2 -p '-1 100' -R 1 county_audit
+) | tee -a $LOGDIR/$LOGTAG.sm
+
+rla_export -e $LOGDIR/$LOGTAG-round1.export

--- a/test/multi/e-1.sh
+++ b/test/multi/e-1.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-../smoketest/main.py reset dos_init
-../smoketest/main.py -c 1 county_setup -f ../multi/adams-regent.csv -F ../multi/adams-manifest.csv
-../smoketest/main.py -c 2 county_setup -f ../multi/alamosa-regent.csv -F ../multi/alamosa-manifest.csv
-../smoketest/main.py dos_start -C 0
-../smoketest/main.py -c 1 county_audit -p '1 3' -R 1
-../smoketest/main.py -c 2 county_audit -p '1 3' -R 1
+./main.py reset dos_init
+./main.py -c 1 county_setup -f ../multi/adams-regent.csv -F ../multi/adams-manifest.csv
+./main.py -c 2 county_setup -f ../multi/alamosa-regent.csv -F ../multi/alamosa-manifest.csv
+./main.py dos_start -C 0
+./main.py -c 1 county_audit -p '1 3' -R 1
+./main.py -c 2 county_audit -p '1 3' -R 1


### PR DESCRIPTION
[Bug: #160911152](https://www.pivotaltracker.com/story/show/160911152)

The multiplicity and number of times we consider having counted a sample now depends on the contest(s) for which a given CVR was selected. This addresses the confusion that would happen if we had estimated 256 samples to audit but recorded that we had audited 512 in the end.