### PR TITLE
rla_export: Remove WHERE cai.counted <> 0

### DIFF
--- a/server/eclipse-project/script/rla_export/rla_export/sql/contest_comparison.sql
+++ b/server/eclipse-project/script/rla_export/rla_export/sql/contest_comparison.sql
@@ -14,7 +14,6 @@ SELECT
    cn.name AS contest_name, 
    cvr_s.imprinted_id,
    cvr_s.ballot_type, 
-   cai.counted,
    SUBSTRING(cci.choices, 2, LENGTH(cci.choices) - 2) AS choice_per_voting_computer,
    SUBSTRING(cci_a.choices, 2, LENGTH(cci_a.choices) - 2) AS audit_board_selection,
    cci_a.consensus,
@@ -41,8 +40,6 @@ FROM
    ON cci.contest_id = cn.id
  LEFT JOIN county AS cty
    ON cn.county_id = cty.id
-
-WHERE cai.counted <> 0 
 
 ORDER BY county_name, contest_name
 ;

--- a/server/eclipse-project/script/rla_export/rla_export/sql/contest_detail.sql
+++ b/server/eclipse-project/script/rla_export/rla_export/sql/contest_detail.sql
@@ -14,7 +14,6 @@ SELECT
    cn.name AS contest_name, 
    cvr_s.imprinted_id,
    cvr_s.ballot_type, 
-   cai.counted,
    SUBSTRING(cci_a.choices, 2, LENGTH(cci_a.choices) - 2) AS audit_board_selection,
    cci_a.consensus,
    LOWER(cvr_s.record_type) as record_type,
@@ -40,8 +39,6 @@ FROM
    ON cci.contest_id = cn.id
  LEFT JOIN county AS cty
    ON cn.county_id = cty.id
-
-WHERE cai.counted <> 0 
 
 ORDER BY county_name, contest_name
 ;


### PR DESCRIPTION
I'm not yet sure if it's ok to remove that WHERE qualification from contest_comparison.sql and contest_detail.sql. But it might be that that count is always nonzero given the other joins in the query with the acvrs. I.e. if an ACVR has been entered, I'd think the cvr would have a non-zero counted.
On the other hand, assume the check was there for a reason, at least originally.

Currently necessary for: `#70 Only counts selections for the contest we care about`
