### PR TITLE
[API] Specify column types for map serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with the following tags indicating the components affected:
   as the RLA export.
 
 ## 2.0.4 - SNAPSHOT - In development
+- [API - Specify column types for map serialization][pr74]
 
 ## 2.0.3 - Bugfix release
 - [API - Only counts selections for the contest we care about][pr70]
@@ -123,3 +124,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr66]: https://github.com/democracyworks/ColoradoRLA/pull/66
 [pr68]: https://github.com/democracyworks/ColoradoRLA/pull/68
 [pr70]: https://github.com/democracyworks/ColoradoRLA/pull/70
+[pr74]: https://github.com/democracyworks/ColoradoRLA/pull/74

--- a/server/eclipse-project/project_configuration/freeandfair_pmd_ruleset.xml
+++ b/server/eclipse-project/project_configuration/freeandfair_pmd_ruleset.xml
@@ -55,6 +55,7 @@ The Free &amp; Fair ruleset checks Java code for possible issues.
   </rule>
   <rule ref="rulesets/java/strictexception.xml"/>
   <rule ref="rulesets/java/strings.xml">
+    <exclude name="AvoidDuplicateLiterals"/>
     <exclude name="ConsecutiveAppendsShouldReuse"/>
   </rule>
   <rule ref="rulesets/java/sunsecure.xml"/>

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CVRAuditInfo.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CVRAuditInfo.java
@@ -83,6 +83,7 @@ public class CVRAuditInfo implements Comparable<CVRAuditInfo>,
    * {Long ComparisonAuditId: Integer count}
    */
   @Convert(converter = LongIntegerMapConverter.class)
+  @Column(columnDefinition = "text")
   private Map<Long,Integer> multiplicity_by_contest = new HashMap<>();
 
   /**
@@ -90,6 +91,7 @@ public class CVRAuditInfo implements Comparable<CVRAuditInfo>,
    * ComparisonAudit
    */
   @Convert(converter = LongIntegerMapConverter.class)
+  @Column(columnDefinition = "text")
   private Map<Long,Integer> count_by_contest = new HashMap<>();
 
   /**


### PR DESCRIPTION
The default choice for persisting a string seems to be `varchar(255)` which won't be sufficient for any realistic map of stuff to things.

I ran into this when trying to run a couple of audits for the 2018 Adams County primary. With XYZ contests on the ballot, our maps were too big to persist so we couldn't move through an audit: the first response would never save.