### PR TITLE
Patch an issue where using _Back_ button freezes UI

### DIFF
--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPage.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPage.tsx
@@ -51,7 +51,7 @@ export const StandardizeContestsPage = (props: PageProps) => {
           </p>
 
           <div className='pt-card'>
-              <StandardizeContestsForm formData={ forms.standardizeContestsForm || {}}
+              <StandardizeContestsForm formData={ _.get(forms, 'standardizeContestsForm', {})}
                                        canonicalContests={ canonicalContests }
                                        contests={ contests } />
           </div>


### PR DESCRIPTION
The way this component is passing props, `forms` could have been `undefined`. Reloading the page seemed to kick the prop downstream, but that's annoying. This seems like a reasonable kludge, but I don't know the proper React way to fix this; got any suggestions?