### PR TITLE
Show signatories from all rounds on the affirmation sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ with the following tags indicating the components affected:
 ## 2.0.5 - SNAPSHOT - In development
 
 - [UI - Remove 'Vote for X' text from data entry and review screens][pr78]
+- [API - Show signatories from all rounds on the affirmation sheet][pr79]
 
 ## 2.0.4 - Bugfix release
 
@@ -134,3 +135,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr73]: https://github.com/democracyworks/ColoradoRLA/pull/73
 [pr74]: https://github.com/democracyworks/ColoradoRLA/pull/74
 [pr78]: https://github.com/democracyworks/ColoradoRLA/pull/78
+[pr79]: https://github.com/democracyworks/ColoradoRLA/pull/79

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -50,6 +50,7 @@ import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyContestResult;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.model.DoSDashboard;
+import us.freeandfair.corla.model.Elector;
 import us.freeandfair.corla.model.Round;
 import us.freeandfair.corla.persistence.Persistence;
 import us.freeandfair.corla.query.CountyContestResultQueries;
@@ -789,31 +790,37 @@ public class CountyReport {
     cell.setCellStyle(standard_style);
     cell.setCellValue(AFFIRMATION_STATEMENT);
 
-    // Use the signatories from the latest round, earlier rounds' signatories
-    // may have already had to leave.
-    //
-    // Signatories are indexed by audit board, so we can just use its size.
-    final int auditBoardCount = my_rounds.get(my_rounds.size() - 1)
-        .signatories()
-        .size();
+    for (int roundIndex = 0; roundIndex < my_rounds.size(); roundIndex++) {
+      final Round round = my_rounds.get(roundIndex);
+      final Map<Integer, List<Elector>> signatories = round.signatories();
+      final List<Integer> boardIndices = new ArrayList(signatories.keySet());
+      Collections.sort(boardIndices);
 
-    for (int boardIndex = 0; boardIndex < auditBoardCount; boardIndex++) {
-      for (int memberIndex = 0; memberIndex < 2; memberIndex++) {
+      cell_number = 0;
+      row_number++;
+      row = affirmation_sheet.createRow(row_number++);
+      cell = row.createCell(cell_number++);
+      cell.setCellType(CellType.STRING);
+      cell.setCellStyle(bold_style);
+      cell.setCellValue(String.format("Round %d", round.number()));
+
+      for (final Integer boardIndex : boardIndices) {
         cell_number = 0;
-        row_number++;
         row = affirmation_sheet.createRow(row_number++);
         cell = row.createCell(cell_number++);
         cell.setCellType(CellType.STRING);
         cell.setCellStyle(bold_style);
-        cell.setCellValue(
-            String.format("Audit Board %d Member", boardIndex + 1));
+        cell.setCellValue(String.format("Audit board %d:", boardIndex + 1));
 
-        cell_number = 0;
-        row = affirmation_sheet.createRow(row_number++);
-        cell = row.createCell(cell_number++);
-        cell.setCellType(CellType.STRING);
-        cell.setCellStyle(box_style);
-        row.setHeight((short) 800);
+        final List<Elector> boardSignatories = signatories.get(boardIndex);
+        for (final Elector signatory : boardSignatories) {
+          cell = row.createCell(cell_number++);
+          cell.setCellType(CellType.STRING);
+          cell.setCellStyle(standard_style);
+          cell.setCellValue(String.format("%s %s",
+              signatory.firstName(),
+              signatory.lastName()));
+        }
       }
     }
 


### PR DESCRIPTION
This shows the signatories for each round, rather than leaving boxes for them to sign. Since the sign-off form *is* their sign-off, having them physically sign paper is redundant.

Resolves [#161129234](https://www.pivotaltracker.com/story/show/161129234).