### PR TITLE
ROUND_COMPLETE_EVENT should transition to WAITING_FOR_ROUND_SIGN_OFF

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMTransitionFunction.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/asm/ASMTransitionFunction.java
@@ -210,19 +210,18 @@ public interface ASMTransitionFunction {
 
     // this can happen if there are no ballots to audit in the first round
     O1(new ASMTransition(AUDIT_INITIAL_STATE,
-                        ROUND_COMPLETE_EVENT,
-                        WAITING_FOR_ROUND_START)),
+                         ROUND_COMPLETE_EVENT,
+                         WAITING_FOR_ROUND_SIGN_OFF)),
 
     // this can happen if there are no ballots to audit in subsequent rounds
     O2(new ASMTransition(WAITING_FOR_ROUND_START,
                          ROUND_COMPLETE_EVENT,
-                         WAITING_FOR_ROUND_START)),
+                         WAITING_FOR_ROUND_SIGN_OFF)),
 
     // this can happen if there are no ballots for an audit board
     O3(new ASMTransition(WAITING_FOR_ROUND_START,
                          ROUND_SIGN_OFF_EVENT,
                          WAITING_FOR_ROUND_START)),
-
 
     /* We probably want this transition eventually, but not for CDOS
     EARLY(new ASMTransition(ROUND_IN_PROGRESS,

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -556,6 +556,7 @@ public final class ComparisonAuditController {
       // FIXME audited prefix length might not mean the same things that
       // it once meant.
       cdb.setAuditedPrefixLength(index + round.startAuditedPrefixLength());
+      cdb.updateAuditStatus();
     }
   }
 

--- a/server/eclipse-project/src/main/resources/log4j.properties
+++ b/server/eclipse-project/src/main/resources/log4j.properties
@@ -1,16 +1,15 @@
 log4j.rootLogger=INFO, stdout
 
-# log4j.logger.us.freeandfair.corla.controller.ComparisonAuditController=DEBUG
-# log4j.logger.us.freeandfair.corla.controller.BallotSelection=INFO
-# log4j.logger.us.freeandfair.corla.endpoint.StartAuditRound=INFO
-# log4j.logger.us.freeandfair.corla.endpoint.SignOffAuditRound=DEBUG
-# log4j.logger.us.freeandfair.corla.endpoint.ACVRUpload=DEBUG
-# log4j.logger.us.freeandfair.corla.model.ComparisonAudit=DEBUG
-# log4j.logger.us.freeandfair.corla.model.CountyDashboard=DEBUG
-# log4j.logger.us.freeandfair.corla.json.DoSDashboardRefreshResponse=DEBUG
+log4j.logger.us.freeandfair.corla.controller.ComparisonAuditController=DEBUG
+log4j.logger.us.freeandfair.corla.controller.BallotSelection=DEBUG
+log4j.logger.us.freeandfair.corla.endpoint.StartAuditRound=DEBUG
+log4j.logger.us.freeandfair.corla.endpoint.SignOffAuditRound=DEBUG
+log4j.logger.us.freeandfair.corla.endpoint.ACVRUpload=DEBUG
+log4j.logger.us.freeandfair.corla.model.ComparisonAudit=DEBUG
+log4j.logger.us.freeandfair.corla.json.DoSDashboardRefreshResponse=DEBUG
 
 # Uncomment to lean more about state machines
-#log4j.logger.us.freeandfair.corla.asm.AbstractStateMachine=DEBUG, stdout
+#log4j.logger.us.freeandfair.corla.asm.AbstractStateMachine=DEBUG
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out

--- a/test/2.0-test-data/second-round-failure.sh
+++ b/test/2.0-test-data/second-round-failure.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Run from test/smoketest
+# Output goes in $LOGDIR (/tmp by default, created if necessary) in files and export directories
+# tagged by $LOGTAG (default "no-round-two")
+
+LOGDIR=${LOGDIR:-/tmp}
+LOGTAG=${LOGTAG:-no-round-two}
+
+mkdir -p $LOGDIR
+
+(
+    echo -e "\nSetup counties 1-5 with the same Adams County CVRs\n"
+    ./main.py reset
+    ./main.py dos_init -r 0.10
+
+    ./main.py -c 1 -f ../2.0-test-data/adams-cvrexport.csv -F ../2.0-test-data/adams-manifest.csv county_setup
+    ./main.py -c 2 -f ../2.0-test-data/adams-cvrexport.csv -F ../2.0-test-data/adams-manifest.csv county_setup
+    ./main.py -c 3 -f ../2.0-test-data/adams-cvrexport.csv -F ../2.0-test-data/adams-manifest.csv county_setup
+    ./main.py -c 4 -f ../2.0-test-data/adams-cvrexport.csv -F ../2.0-test-data/adams-manifest.csv county_setup
+    ./main.py -c 5 -f ../2.0-test-data/adams-cvrexport.csv -F ../2.0-test-data/adams-manifest.csv county_setup
+
+    ./main.py -C 0 -s 12345678901234567890 dos_start
+    echo -e "\nStatewide Regent targeted at 10% and started."
+    echo -e "4 ballots in Adams County\n"
+    echo -e "0 ballots in Alamosa County\n"
+    echo -e "2 ballots in Arapaho County\n"
+    echo -e "0 ballots in Archuleta County\n"
+    echo -e "3 ballots in Baca County\n"
+) | tee $LOGDIR/$LOGTAG.sm
+
+#rla_export -e $LOGDIR/$LOGTAG-setup.export
+
+echo -e "Press <RET> when ready to start round one."
+read
+
+(
+    echo -e "One discrepancies in Adams County\n"
+    ./main.py -c 1 -p '1 4' -R 1 county_audit
+
+    echo -e "\nAlamosa County has nothing to do and signs-off\n"
+    ./main.py -c 2 login_signoff_round
+
+    echo -e "\nZero discrepancy in Arapaho County\n"
+    ./main.py -c 3 -p '-1 100' -R 1 county_audit
+
+    echo -e "\nArchuleta County has nothing to do and signs-off\n"
+    ./main.py -c 4 login_signoff_round
+
+    echo -e "\nZero discrepancy in Baca County\n"
+    ./main.py -c 5 -p '-1 100' -R 1 county_audit
+
+    echo -e "\nEveryone should be waiting for round start"
+) | tee -a $LOGDIR/$LOGTAG.sm
+
+
+echo -e "Press <RET> when ready to start round two."
+read
+
+(
+    ./main.py start_audit_round
+    echo -e "Adams County has nothing to do and signs-off\n"
+    ./main.py -c 1 login_signoff_round
+
+    echo -e "\nAlamosa County has nothing to do and signs-off\n"
+    ./main.py -c 2 login_signoff_round
+
+    echo -e "\nArapaho County has nothing to do and signs-off\n"
+    ./main.py -c 3 login_signoff_round
+
+    echo -e "\nZero discrepancy in Archuleta County\n"
+    ./main.py -c 4 -p '-1 1' -R 1 county_audit
+
+    echo -e "\nZero discrepancy in Baca County\n"
+    ./main.py -c 5 -p '-1 100' -R 1 county_audit
+
+    echo -e "\nAudit should be complete"
+) | tee -a $LOGDIR/$LOGTAG.sm
+
+
+    echo -e "\nM"


### PR DESCRIPTION
Here's a PR that [resolves #161131395](https://www.pivotaltracker.com/story/show/161131395). In short, we should sign off on every round whether there's work to do or not.

If you read the commits in order, you should be able to playback the experience. The script in `d3bc8fc` should leave you in a stuck audit if you checkout the branch at that point; the branch at `49d9d70` should let you get through a second round.