### PR TITLE
[dashboard] change meaning of ballotsRemainingInCurrentRound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with the following tags indicating the components affected:
   as the RLA export.
 
 ## 2.0.8 - SNAPSHOT - In development
+- [API - change meaning of ballotsRemainingInCurrentRound][pr88]
 
 ## 2.0.7 - Bugfix release
 
@@ -155,3 +156,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr83]: https://github.com/democracyworks/ColoradoRLA/pull/83
 [pr85]: https://github.com/democracyworks/ColoradoRLA/pull/85
 [pr86]: https://github.com/democracyworks/ColoradoRLA/pull/86
+[pr88]: https://github.com/democracyworks/ColoradoRLA/pull/88

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -50,7 +50,6 @@ import javax.persistence.Version;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
-import us.freeandfair.corla.controller.BallotSelection;
 import us.freeandfair.corla.model.ImportStatus.ImportState;
 
 import us.freeandfair.corla.persistence.AuditSelectionIntegerMapConverter;
@@ -577,8 +576,6 @@ public class CountyDashboard implements PersistentEntity {
    * @return the number of ballots remaining in the current round, or 0
    * if there is no current round.
    */
-  // FIXME this is broken; round's expected and actual don't match what
-  // the dashboard sees.
   public int ballotsRemainingInCurrentRound() {
     final int result;
 
@@ -587,17 +584,16 @@ public class CountyDashboard implements PersistentEntity {
     } else {
 
       final Round round = currentRound();
-      final Integer prefix = BallotSelection.auditedPrefixLength(round.ballotSequence());
-      result = round.ballotSequence().size() - prefix;
+
+      result = round.ballotSequence().size() - this.auditedSampleCount();
 
       LOGGER.debug(String.format("[ballotsRemainingInCurrentRound:"
-                                 + " index=%d, result=%d, prefix=%d,"
+                                 + " index=%d, result=%d,"
                                  + " ballotSequence=%s"
                                  + " ballotSequence.size=%d"
                                  + " cdb.auditedSampleCount()=%d]",
                                  my_current_round_index,
                                  result,
-                                 prefix,
                                  round.ballotSequence(),
                                  round.ballotSequence().size(),
                                  this.auditedSampleCount()));


### PR DESCRIPTION
With a large sample size in a round computing the audited prefix length is too expensive an operation. With 682 samples the request to the county dashboard took 10 seconds. Without it, the request took 0.2 seconds. This also makes the info more clear on the dashboard and we have wanted to do this for some time. This is the answer to the question: "How many ballots until the end of the round", truthfully. There  may be a place for audited prefix length, but I don't think it is on the dashboard.