### PR TITLE
Prevent text selection on audit buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ with the following tags indicating the components affected:
   as the RLA export.
 
 ## 2.0.8 - SNAPSHOT - In development
+
 - [API - change meaning of ballotsRemainingInCurrentRound][pr88]
+- [UI - Prevent text selection on audit buttons][pr90]
 
 ## 2.0.7 - Bugfix release
 
@@ -157,3 +159,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr85]: https://github.com/democracyworks/ColoradoRLA/pull/85
 [pr86]: https://github.com/democracyworks/ColoradoRLA/pull/86
 [pr88]: https://github.com/democracyworks/ColoradoRLA/pull/88
+[pr90]: https://github.com/democracyworks/ColoradoRLA/pull/90

--- a/client/screen.css
+++ b/client/screen.css
@@ -328,6 +328,11 @@ th.rla-county-contest-info {
     align-items: center;
     justify-content: center;
     transition: all 0.2s ease;
+    /* Prevent issues with text selection interfering with button clicks */
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .choice-name:hover {


### PR DESCRIPTION
There is a subtle issue where browsers are capturing user clicks and interpreting them as starting text selection rather than a button click. This makes it slightly harder to miss clicking a button by preventing text selection on the buttons on the audit board selection screen altogether.