### PR TITLE
Test against PostgreSQL 9.6

### DIFF
--- a/docker/postgresql/Dockerfile
+++ b/docker/postgresql/Dockerfile
@@ -1,5 +1,9 @@
-FROM postgres:9.2
+FROM postgres:9.6
 LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
 
 COPY docker/postgresql/init-corla-db.sh /docker-entrypoint-initdb.d/init-corla-db.sh
+COPY docker/postgresql/postgresql.conf /etc/postgresql
 COPY test/corla-test-credentials.psql /root/corla-test-credentials.psql
+
+# Override default postgres config file
+CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/docker/postgresql/postgresql.conf
+++ b/docker/postgresql/postgresql.conf
@@ -1,0 +1,32 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+max_connections = 100			# (change requires restart)
+shared_buffers = 256MB			# min 128kB
+shared_preload_libraries='pg_stat_statements'
+checkpoint_segments = 10		# in logfile segments, min 1, 16MB each
+log_min_messages = debug1		# values in order of decreasing detail:
+log_line_prefix = '<%t-%i> '
+log_timezone = 'UTC'
+datestyle = 'iso, mdy'
+timezone = 'UTC'
+lc_messages = 'en_US.UTF-8'			# locale for system error message
+lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'			# locale for number formatting
+lc_time = 'en_US.UTF-8'				# locale for time formatting
+default_text_search_config = 'pg_catalog.english'


### PR DESCRIPTION
This is the version pof PostgreSQL that CDOS is using.  This PR adds a mostly-default config: `checkpoint_segments = 10` should stop the log-spam about checkpoints happening to frequently, and `log_min_messages=debug1` gets us a hair more insight. I have no idea why `Navajo` is the default timezone; UTC makes more sense to me.