### PR TITLE
Profiling inside containers

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -11,12 +11,19 @@ RUN mvn package
 FROM openjdk:8
 LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
 
+RUN wget https://www.yourkit.com/download/docker/YourKit-JavaProfiler-2018.04-docker.zip -P /tmp/ && \
+  unzip /tmp/YourKit-JavaProfiler-2018.04-docker.zip -d /usr/local && \
+  rm /tmp/YourKit-JavaProfiler-2018.04-docker.zip
+
 ## TODO: How can we architect this such that passing -Dthe.prop=value works as
 ## expected?
 COPY docker/server/docker.properties /srv/corla/docker.properties
 COPY --from=maven /srv/corla/server/eclipse-project/target/corla-server-*-shaded.jar \
      /srv/corla/corla.jar
 
+EXPOSE 10001
+
 CMD ["java", \
+     "-agentpath:/usr/local/YourKit-JavaProfiler-2018.04/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all", \
      "-jar", "/srv/corla/corla.jar", \
      "/srv/corla/docker.properties"]


### PR DESCRIPTION
If we're going to be scaling our testing environment past laptop sizes, it might be useful to be able to run a profiler on a remote host. This PR [adds the YourKit agent][1] to the Dockerized application. Additionally, the test environment will need to open port `10001` for the profiler to connect to the agent.

I've successfully tested this on my machine:
![remote profiling](https://user-images.githubusercontent.com/104658/47922205-1ede5b80-de7c-11e8-9227-3e38f489bd63.png)
![docker containers](https://user-images.githubusercontent.com/104658/47922216-27369680-de7c-11e8-826a-12378454e949.png)


[1]: https://www.yourkit.com/docs/java/help/docker.jsp 