### PR TITLE
Correctly identify overvotes submitted by an audit board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ with the following tags indicating the components affected:
   etc.
 - `TOOLING` refers to changes to tooling that falls outside the UI or API, such
   as the RLA export.
+
 ## 2.0.10 - SNAPSHOT - In development
 
+- [API - Correctly identify overvotes submitted by an audit board][pr97]
 - [API - Database host should be configurable][pr98]
 
 ## 2.0.9 - Bugfix release
@@ -170,4 +172,5 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr89]: https://github.com/democracyworks/ColoradoRLA/pull/89
 [pr90]: https://github.com/democracyworks/ColoradoRLA/pull/90
 [pr93]: https://github.com/democracyworks/ColoradoRLA/pull/93
+[pr97]: https://github.com/democracyworks/ColoradoRLA/pull/97
 [pr98]: https://github.com/democracyworks/ColoradoRLA/pull/98

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyContestComparisonAudit.java
@@ -813,12 +813,15 @@ public class CountyContestComparisonAudit implements PersistentEntity {
                      "checkstyle:methodlength"})
   private OptionalInt computeAuditedBallotDiscrepancy(final CVRContestInfo the_cvr_info,
                                                       final CVRContestInfo the_acvr_info) {
-    // check for overvotes
+    // Check for overvotes.
+    //
+    // See the ComparisonAudit class for more details. In short, if we have an
+    // overvoted ACVR we record no selections for that contest, matching the
+    // CVR format.
     final Set<String> acvr_choices = new HashSet<>();
-    // TODO: validate choices().size()
-    // if (the_acvr_info.choices().size() <= my_contest_result.votesAllowed()) {
+    if (the_acvr_info.choices().size() <= my_contest_result.winnersAllowed()) {
       acvr_choices.addAll(the_acvr_info.choices());
-    // } // else overvote so don't count the votes
+    }
 
     // avoid linear searches on CVR choices
     final Set<String> cvr_choices = new HashSet<>(the_cvr_info.choices());


### PR DESCRIPTION
The CVR format shows no selections in the event of an overvote. To make the audit board selections match in the event of an overvote, we therefore have to exclude all selections when the audit board records an overvote in order to have a chance at matching the CVR if indeed there was an overvote.

More detail around this has been added to the code responsible for dealing with it.