### PR TITLE
Database URL should be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ with the following tags indicating the components affected:
   as the RLA export.
 ## 2.0.10 - SNAPSHOT - In development
 
+- [API - Database host should be configurable][pr98]
+
 ## 2.0.9 - Bugfix release
 
 - [API - Contests that are NOT_AUDITABLE don't impede progress][pr93]
@@ -168,3 +170,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr89]: https://github.com/democracyworks/ColoradoRLA/pull/89
 [pr90]: https://github.com/democracyworks/ColoradoRLA/pull/90
 [pr93]: https://github.com/democracyworks/ColoradoRLA/pull/93
+[pr98]: https://github.com/democracyworks/ColoradoRLA/pull/98

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
@@ -256,7 +256,8 @@ public final class Persistence {
       settings.put(Environment.ORDER_INSERTS, TRUE);
       settings.put(Environment.ORDER_UPDATES, TRUE);
       settings.put(Environment.BATCH_VERSIONED_DATA, TRUE);
-      settings.put(Environment.STATEMENT_BATCH_SIZE, "100");
+      settings.put(Environment.STATEMENT_BATCH_SIZE,
+                   system_properties.getProperty("hibernate.jdbc.batch_size", "100"));
       settings.put(Environment.BATCH_FETCH_STYLE, "DYNAMIC");
       settings.put(Environment.VALIDATE_QUERY_PARAMETERS, FALSE);
       settings.put(Environment.DEFAULT_BATCH_FETCH_SIZE, "16");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
@@ -126,6 +126,11 @@ public final class Persistence {
    */
   public static synchronized void setProperties(final Properties the_properties) {
     system_properties = the_properties;
+    final Map<String, String> env = System.getenv();
+
+    if (env.containsKey("HIBERNATE_URL")) {
+      system_properties.setProperty("hibernate.url", env.get("HIBERNATE_URL"));
+    }
   }
 
   /**


### PR DESCRIPTION
For those cases where we might want to deploy the server in a container to different places, we can provide the Hibernate URL as an environment variable to supersede what's hard coded in `default.properties`. While I was there, I noticed the JDBC batch size was fixed to 100. This might or might not be the best value - [Hibernate documentation mentions 10-50 as starting values](http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#batch-jdbcbatch) - so let's not hard code it.