### PR TITLE
Fix bad audit board regex that caught just a single digit

### DIFF
--- a/client/src/reducer/county/dashboardRefreshOk.ts
+++ b/client/src/reducer/county/dashboardRefreshOk.ts
@@ -2,9 +2,29 @@ import { isEmpty, merge } from 'lodash';
 
 import { parse } from 'corla/adapter/countyDashboardRefresh';
 
-// XXX: Audit board index hack
+/*
+ * XXX: Audit board index hack
+ *
+ * We ran out of time to get this working the "right" way which would have
+ * involved a session and the server knowing which board was currently signed
+ * in. Because this state information is overwritten by dashboard refresh
+ * responses, we need to shim in the client's idea of the current audit board
+ * just before we merge the response into the local application state, which
+ * this function helps us to do.
+ *
+ * We don't get access to component-local state from reducers, so we can't
+ * simply read it out of the component either. There is a better way to do this
+ * involving an action emitted from the button that the audit board selects to
+ * sign in which sets some state that is not overwritten by dashboard refresh
+ * responses, but this method suffices for the time being and is at least
+ * localized to this place in the code, and can be replaced with a better method
+ * in the future without cascading changes.
+ *
+ * This method retains the benefit of allowing users to sign in multiple audit
+ * boards in the same browser session, because the state is held in the URL.
+ */
 const auditBoardIndexFromUrl = () => {
-    const re = /^\/county\/board\/(\d)$/;
+    const re = /^\/county\/board\/(\d+)$/;
     const matches = window.location.pathname.match(re);
 
     if (!matches) {
@@ -13,7 +33,6 @@ const auditBoardIndexFromUrl = () => {
 
     return matches[1];
 };
-
 
 export default function dashboardRefreshOk(
     state: County.AppState,


### PR DESCRIPTION
As you can tell by the comment, I'm not proud of this, but at least it's just localized to this spot in the code - a future fix to get this working the "right" way wouldn't be too invasive.