### PR TITLE
[ballot-selection] restore random order after query for cvrs

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
@@ -12,6 +12,7 @@
 package us.freeandfair.corla.query;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -426,7 +427,31 @@ public final class CastVoteRecordQueries {
 
     results.addAll(phantomRecords);
 
-    return results;
+    // this is a dummy list so we can add a cvr at a particular position(that of
+    // the tributes uris)
+    final List<CastVoteRecord> randomOrder =
+      new ArrayList<CastVoteRecord>(Collections.nCopies(uris.size(), null));
+
+    // line the cvrs back up into the random order
+    for (final CastVoteRecord cvr: results) {
+      int index = 0;
+      for (final String uri: uris) {
+        if (uri.equals(cvr.getUri())) {
+          randomOrder.add(index, cvr);
+        }
+        index++;
+      }
+    }
+
+    final List<CastVoteRecord> returnList = randomOrder.stream()
+      .filter(cvr -> null != cvr)
+      .collect(Collectors.toList());
+    if (returnList.size() != uris.size()) {
+      // we got a problem here
+      Main.LOGGER.error("something went wrong with atPosition - returnList.size() != uris.size()");
+    }
+
+    return returnList;
   }
 
   /**


### PR DESCRIPTION
We inadvertently dropped the random order that was stored on round.audit_subsequence when we queried the cvrs in bulk during selection. This will put the order back.
