### PR TITLE
Don't show negative numbers of estimated samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ with the following tags indicating the components affected:
 
 ## 2.0.12 - SNAPSHOT - In development
 
+- [API - Don't show negative numbers of estimated samples][pr106]
+
 ## 2.0.11 - Bugfix release
+
 - [INFRA - smoketest to use python3][cma60b5]
 - [API - some debug logging removed][cm506cf]
 - [UI - update instruction text][pr101]
@@ -186,3 +189,4 @@ This is [FreeAndFair's most recent tag][1.1.0.3].
 [pr101]: https://github.com/democracyworks/ColoradoRLA/pull/101
 [cm506cf]: https://github.com/democracyworks/ColoradoRLA/commit/506cf568901ce6f1ba8e2085369444d88f802ff6
 [cma60b5]: https://github.com/democracyworks/ColoradoRLA/commit/a60b5972b9f6b1a68d4b22cf06721dd41e5a7374
+[pr106]: https://github.com/democracyworks/ColoradoRLA/pull/106

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
@@ -180,13 +180,11 @@ public class DoSDashboardRefreshResponse {
       switch (cta.audit()) {
         case COMPARISON:
           final Map<Integer, Integer> discrepancy = new HashMap<>();
-          int optimistic = Integer.MIN_VALUE;
-          int estimated = Integer.MIN_VALUE;
+          int optimistic = 0;
+          int estimated = 0;
           audited_contests.put(cta.contest().id(), cta.reason());
 
-          // FIXME does looking up the ComparisonAudit by name make sense?
           for (final ComparisonAudit ca : ComparisonAuditQueries.matching(cta.contest().name())) {
-            // FIXME The dashboard looks funny here.
             optimistic = Math.max(optimistic, Math.max(0, ca.optimisticSamplesToAudit() - ca.getAuditedSampleCount()));
             estimated = Math.max(estimated, Math.max(0, ca.estimatedSamplesToAudit() - ca.getAuditedSampleCount()));
 
@@ -203,13 +201,6 @@ public class DoSDashboardRefreshResponse {
             }
           }
 
-          // FIXME Should we return the ContestResult that is the
-          // aggregate of many Contests? Doing so would take us in the
-          // direction of being able to clean up the UI; otherwise,
-          // we'll have 64 - minus 2 or 3 - Governor contests littering
-          // the screen. A similar thing would happen for smaller
-          // cardinality contests, like a Congressional District race
-          // which might affect 4 or 5 counties.
           estimated_ballots_to_audit.put(cta.contest().id(), optimistic);
           optimistic_ballots_to_audit.put(cta.contest().id(), estimated);
           discrepancy_count.put(cta.contest().id(), discrepancy);

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/DoSDashboardRefreshResponse.java
@@ -185,8 +185,8 @@ public class DoSDashboardRefreshResponse {
           audited_contests.put(cta.contest().id(), cta.reason());
 
           for (final ComparisonAudit ca : ComparisonAuditQueries.matching(cta.contest().name())) {
-            optimistic = Math.max(optimistic, Math.max(0, ca.optimisticSamplesToAudit() - ca.getAuditedSampleCount()));
-            estimated = Math.max(estimated, Math.max(0, ca.estimatedSamplesToAudit() - ca.getAuditedSampleCount()));
+            optimistic = ca.optimisticRemaining();
+            estimated = ca.estimatedRemaining();
 
             LOGGER.debug(String.format("[createResponse: optimistic=%d, estimated = %d, ca.optimisticSamplesToAudit()=%d, ca.estimatedSamplesToAudit()=%d, ca.getAuditedSampleCount()=%d]",
                                        optimistic, estimated, ca.optimisticSamplesToAudit(), ca.estimatedSamplesToAudit(), ca.getAuditedSampleCount()));

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
@@ -430,7 +430,7 @@ public class ComparisonAudit implements PersistentEntity {
 
   /** estimatedSamplesToAudit minus getAuditedSampleCount **/
   public final Integer estimatedRemaining() {
-    return estimatedSamplesToAudit() - getAuditedSampleCount();
+    return Math.max(0, estimatedSamplesToAudit() - getAuditedSampleCount());
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
@@ -433,6 +433,11 @@ public class ComparisonAudit implements PersistentEntity {
     return Math.max(0, estimatedSamplesToAudit() - getAuditedSampleCount());
   }
 
+  /** optimisticSamplesToAudit minus getAuditedSampleCount **/
+  public final Integer optimisticRemaining() {
+    return Math.max(0, optimisticSamplesToAudit() - getAuditedSampleCount());
+  }
+
   /**
    * @return the expected overall number of ballots to audit, assuming
    * overstatements continue to occur at the current rate.


### PR DESCRIPTION
A floor of zero is practical when the question is "how many things more do I need to touch?". There is a zero that you'll see until we get a value calculated, but that seems more accurate than `Integer.MIN_VALUE` as a magic number.

Resolves [#162392809](https://www.pivotaltracker.com/story/show/162392809)