### PR TITLE
User interface for re-auditing ballots

### DIFF
--- a/client/action.d.ts
+++ b/client/action.d.ts
@@ -26,6 +26,7 @@ declare namespace Action {
         | ImportCvrExportOk
         | Login1FOk
         | SelectContestsForAuditOk
+        | SetAuditBoard
         | UpdateAcvrForm
         | UploadBallotManifestOk
         | UploadAcvrFail
@@ -140,6 +141,13 @@ declare namespace Action {
     interface SelectContestsForAuditOk {
         type: 'SELECT_CONTESTS_FOR_AUDIT_OK';
         data: any;
+    }
+
+    interface SetAuditBoard {
+        type: 'SET_AUDIT_BOARD';
+        data: {
+            auditBoardIndex: number;
+        };
     }
 
     interface UpdateAcvrForm {

--- a/client/action.d.ts
+++ b/client/action.d.ts
@@ -23,8 +23,10 @@ declare namespace Action {
         | FetchCountyASMStateOk
         | FetchCvrsToAuditOk
         | FetchDOSASMStateOk
+        | FinalReviewComplete
         | ImportCvrExportOk
         | Login1FOk
+        | ReAuditCvr
         | SelectContestsForAuditOk
         | SetAuditBoard
         | UpdateAcvrForm
@@ -128,6 +130,11 @@ declare namespace Action {
         data: any;
     }
 
+    interface FinalReviewComplete {
+        type: 'FINAL_REVIEW_COMPLETE',
+        data: any,
+    }
+
     interface ImportCvrExportOk {
         type: 'IMPORT_CVR_EXPORT_OK';
         data: any;
@@ -148,6 +155,14 @@ declare namespace Action {
         data: {
             auditBoardIndex: number;
         };
+    }
+
+    interface ReAuditCvr {
+        type: 'RE_AUDIT_CVR';
+        data: {
+            comment: string;
+            cvrId: number;
+        }
     }
 
     interface UpdateAcvrForm {

--- a/client/county.d.ts
+++ b/client/county.d.ts
@@ -28,6 +28,7 @@ declare namespace County {
         election?: Election;
         estimatedBallotsToAudit?: number;
         fileName?: string;  // TODO: remove
+        finalReview: FinalReview;
         hash?: string;  // TODO: remove
         id?: number;
         riskLimit?: number;
@@ -98,4 +99,10 @@ declare namespace County {
         | 'COUNTY_AUDIT_UNDERWAY'
         | 'COUNTY_AUDIT_COMPLETE'
         | 'DEADLINE_MISSED';
+
+    interface FinalReview {
+        ballotId?: number;
+        comment?: string;
+        complete: boolean;
+    }
 }

--- a/client/county.d.ts
+++ b/client/county.d.ts
@@ -2,7 +2,6 @@ declare namespace County {
     interface AppState {
         acvrs: ACVRs;
         asm: ASMStates;
-        // XXX: Audit board index hack
         auditBoardIndex?: number;
         auditBoards: AuditBoards;
         auditBoardCount?: number;

--- a/client/json.d.ts
+++ b/client/json.d.ts
@@ -37,6 +37,8 @@ declare namespace JSON {
     interface ACVR {
         audit_cvr: JSON.CVR;
         cvr_id: number;
+        reaudit?: boolean;
+        comment?: string;
     }
 
     interface Round {

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -1,22 +1,22 @@
 {
   "name": "corla-client",
-  "version": "2.0.12",
+  "version": "2.0.12-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@blueprintjs/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-UVbIL/ZHKobuPDb8VXd9w71utYTJeU/8eYUJCsLBAgmH8Y4WA9joxZ22PFrJ+6a/T0Hf1rN6Tfd6EMWDqxA18g==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-1.40.0.tgz",
+      "integrity": "sha512-5qXiFLOZwKzKZFi+IVgiMictOfZPpkclgdpzte2BpZ4ptlNitFiK79aRmDu1O7rnA1iiR0EJRrE8p9gr95USRw==",
       "requires": {
-        "@types/dom4": "^1.5.20",
-        "@types/tether": "^1.1.27",
-        "classnames": "^2.2",
-        "dom4": "^1.8",
+        "@types/dom4": "1.5.20",
+        "@types/tether": "1.4.4",
+        "classnames": "2.2.5",
+        "dom4": "1.8.5",
         "normalize.css": "4.1.1",
-        "pure-render-decorator": "^1.1",
-        "tether": "^1.4",
-        "tslib": "^1.5.0"
+        "pure-render-decorator": "1.2.1",
+        "tether": "1.4.5",
+        "tslib": "1.7.1"
       }
     },
     "@blueprintjs/datetime": {
@@ -24,11 +24,11 @@
       "resolved": "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-1.19.0.tgz",
       "integrity": "sha512-foclNeSwUgp/dHezR5UY53qooddtSuKtOWGroG/hHhtJM+R2cprS4zwWYAH0gb5Hu2DhzwbC1i5qpRAG3spAXg==",
       "requires": {
-        "@blueprintjs/core": "^1.3.0",
-        "classnames": "^2.2",
-        "moment": "^2.14.1",
-        "react-day-picker": "^5.3.0",
-        "tslib": "^1.5.0"
+        "@blueprintjs/core": "1.40.0",
+        "classnames": "2.2.5",
+        "moment": "2.18.1",
+        "react-day-picker": "5.5.3",
+        "tslib": "1.7.1"
       }
     },
     "@blueprintjs/labs": {
@@ -36,10 +36,10 @@
       "resolved": "https://registry.npmjs.org/@blueprintjs/labs/-/labs-0.5.0.tgz",
       "integrity": "sha512-l1isR/rwAe+o8gwou7kJYlKHyaDrka4Zo/lyRcPDivfk9Kjoqm+PajGG/dvN57Eo7L/FCD92WPk4wqcsp04hGg==",
       "requires": {
-        "@blueprintjs/core": "^1.23.0",
-        "classnames": "^2.2",
+        "@blueprintjs/core": "1.40.0",
+        "classnames": "2.2.5",
         "pure-render-decorator": "1.2.1",
-        "tslib": "^1.5.0"
+        "tslib": "1.7.1"
       }
     },
     "@types/cheerio": {
@@ -50,15 +50,15 @@
     "@types/dom4": {
       "version": "1.5.20",
       "resolved": "https://registry.npmjs.org/@types/dom4/-/dom4-1.5.20.tgz",
-      "integrity": "sha512-6jus4M/gO6M+yIQ1uu/EDpFsOtK0vMyRyQPeO+TSMtC0Wi2rBVPUGjAFSszkvpzpzTkorWILilCeIdFehlKLTw=="
+      "integrity": "sha1-zPY207eU/mWkGR68f/l5p47+psI="
     },
     "@types/enzyme": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-2.8.5.tgz",
       "integrity": "sha512-l/SLhEoJOmSBy1GGWXcLJxU4FGbRhXDk5c7kAqMiBPhjmLyBBXSiUELQKn+6TgZFjGS4F8hfX5snQr5WHZ/9kA==",
       "requires": {
-        "@types/cheerio": "*",
-        "@types/react": "*"
+        "@types/cheerio": "0.22.2",
+        "@types/react": "15.6.5"
       }
     },
     "@types/fetch-mock": {
@@ -86,7 +86,7 @@
       "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.2.35.tgz",
       "integrity": "sha512-HG4pUK/fTrGY3FerMlINxK74MxdAxkCRYrp5AM+oJ2jLcK0jWUi64ZV15JKwDR4TYLIxrT3y9SVnEWcLPbC/YA==",
       "requires": {
-        "moment": ">=2.14.0"
+        "moment": "2.18.1"
       }
     },
     "@types/node": {
@@ -104,7 +104,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-15.5.6.tgz",
       "integrity": "sha512-dP4vEDEH4rL+uUl6f//c6mjepTVdJ6Ldx3z0dZbw047T5Z+o2PZDW/Qd+I4PkTmIgk7YNAZC/TFnm3IHT5UAhw==",
       "requires": {
-        "@types/react": "^15"
+        "@types/react": "15.6.5"
       }
     },
     "@types/react-dropzone": {
@@ -112,7 +112,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dropzone/-/react-dropzone-4.2.0.tgz",
       "integrity": "sha512-Al+MGP68e/ZQ5TA+swaSiBr1taI1aMdEMxlvk8Ofsx+AK8WD9zrtblAXuVZt51dx4rZwiNGXG6vtLduS94rkdQ==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "15.6.5"
       }
     },
     "@types/react-redux": {
@@ -120,8 +120,8 @@
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-5.0.11.tgz",
       "integrity": "sha512-onugzQGhohicl5dOBF4yeU+2uqBSL7hEyTEOd71t/QawpvaAFRv4ML1jhqaxSGnnLVG8BudmoKdsj7UVYnsP5w==",
       "requires": {
-        "@types/react": "*",
-        "redux": "^3.6.0"
+        "@types/react": "15.6.5",
+        "redux": "3.7.2"
       }
     },
     "@types/react-router": {
@@ -129,8 +129,8 @@
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.14.tgz",
       "integrity": "sha512-wbcqBGFv2KcBo0fIief2MJeE5e1Ph9Z35FzWPmadNMzd5dwpFGLVxyDQiLc30u3ehNrgG7JlQcFYLe5YJnToyA==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*"
+        "@types/history": "4.6.0",
+        "@types/react": "15.6.5"
       }
     },
     "@types/react-router-dom": {
@@ -138,9 +138,9 @@
       "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.0.7.tgz",
       "integrity": "sha512-U0MRf2YP/Bf23jKc+9rh9Ugn2JuAGUFfgMGnaHlL5iX7m8VvE5Mt+vuHikR10nysduEUg1Etc8xwBcLEh7E3rw==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*"
+        "@types/history": "4.6.0",
+        "@types/react": "15.6.5",
+        "@types/react-router": "4.0.14"
       }
     },
     "@types/redux-mock-store": {
@@ -148,8 +148,8 @@
       "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-0.0.9.tgz",
       "integrity": "sha512-Azxv7Yx8qN8K/YkYjB9OUJZXZ3vkoSEk7VqvgKl9h2FuGwzyakGdRUQxZfOdTbC1cUB9vJRWZcFQrhR3kIEITA==",
       "requires": {
-        "redux": "^3.6.0",
-        "redux-mock-store": "^1.2.3"
+        "redux": "3.7.2",
+        "redux-mock-store": "1.2.3"
       }
     },
     "@types/sinon": {
@@ -162,13 +162,13 @@
       "resolved": "https://registry.npmjs.org/@types/tape/-/tape-4.2.31.tgz",
       "integrity": "sha512-DEPn8FJKQR6eeMHZ407TuAqlhBKQa54PTM3c7Z6pKOI1uHaPnidmpmOXYtNZTcDrL5hnZofSHPwX1AQ9HbaMUg==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "8.0.47"
       }
     },
     "@types/tether": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/tether/-/tether-1.4.2.tgz",
-      "integrity": "sha512-PDiVAkmxFc3HGUQAguc1++Rbpi7jhp6Gtd+So2JRRPKHcsXO4a6UB+eUFx+XO++F8wJH3b2phnKCEYg8/NkDow=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/tether/-/tether-1.4.4.tgz",
+      "integrity": "sha512-6qhsFJVMuMqaQRVyQVi3zUBLfKYyryktL0ZP0Z3zegzeQ7WKm0PZNCdl3JsaitJbzqaoQ9qsFKMfaj5MiMfcSQ=="
     },
     "@types/webpack-env": {
       "version": "1.13.0",
@@ -180,7 +180,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha512-AOPopplFOUlmUugwiZUCDpOwmqvSgdCyE8iJVLWI4NcB7qfMKQN34dn5xYtlUU03XGG5egRWW4NW5gIxpa5hEA==",
       "requires": {
-        "mime-types": "~2.1.11",
+        "mime-types": "2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -194,7 +194,7 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha512-GKp5tQ8h0KMPWIYGRHHXI1s5tUpZixZ3IHF2jAu42wSCf6In/G873s6/y4DdKdhWvzhu1T6mE1JgvnhAKqyYYQ==",
       "requires": {
-        "acorn": "^4.0.3"
+        "acorn": "4.0.13"
       },
       "dependencies": {
         "acorn": {
@@ -214,8 +214,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -228,9 +228,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "kind-of": {
@@ -238,7 +238,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -268,8 +268,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -277,7 +277,7 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -290,9 +290,9 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "expand-brackets": {
@@ -300,7 +300,7 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -308,7 +308,7 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -321,7 +321,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         },
         "micromatch": {
@@ -329,19 +329,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
           }
         }
       }
@@ -381,7 +381,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -409,9 +409,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha512-2bgTMPN2ajcSKk7lxDNHdBzhikvJP0F2RYoAeaECCWliwixxKxOd1YCT9nulJem1SbQ0eFI5b6w6Ux8fwxACLg==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "assert": {
@@ -442,7 +442,7 @@
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
       "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
       "requires": {
-        "core-js": "^2.5.0"
+        "core-js": "2.5.7"
       },
       "dependencies": {
         "core-js": {
@@ -457,14 +457,14 @@
       "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.2.2.tgz",
       "integrity": "sha512-8F8rFsOIT4HQDKXt+5Dz66qhiC2pOAbfhsbOj3DeW0LATxxBPQPx0vxCxmecfEroTyKDYBiBMod2cXrChcQa4w==",
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.1.2",
         "enhanced-resolve": "3.3.0",
-        "loader-utils": "^1.1.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^3.0.3",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.1",
-        "source-map-support": "^0.4.15"
+        "loader-utils": "1.1.0",
+        "lodash": "4.17.4",
+        "micromatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "source-map-support": "0.4.15"
       }
     },
     "babel-code-frame": {
@@ -472,9 +472,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha512-Dmx3yJCO/UHWgFTKUlBPHUm7h5hCjI5Lfc07gmSv7H4AbUwxS7NHyorp8HN1YEd4xSDCf7P4zqnS63I3aaJTwg==",
       "requires": {
-        "chalk": "^1.1.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-messages": {
@@ -482,7 +482,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-runtime": {
@@ -490,8 +490,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
       "integrity": "sha512-zeCYxDePWYAT/DfmQWIHsMSFW2vv45UIwIAMjGvQVsTd47RwsiRH0uK1yzyWZ7LDBKdhnGDPM6NYEO5CZyhPrg==",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.10.0"
+        "core-js": "2.5.0",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "core-js": {
@@ -506,11 +506,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha512-Ak4qz4gxFYXuj3O5m+Um2RvhZw2CUVTDM3sMK5XhrJLRfIFi7nxCwBLCG0RBwqNzo7DVM996bHlo6kSkJ0X/jg==",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.25.0",
-        "babel-types": "^6.25.0",
-        "babylon": "^6.17.2",
-        "lodash": "^4.2.0"
+        "babel-runtime": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "lodash": "4.17.4"
       }
     },
     "babel-traverse": {
@@ -518,15 +518,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha512-nTp4cMQ6tI37rTmE0oUBQKJVxdwKhz0Wzh5KzaV2a+GjdkGDdJV7Vz2aAIWQqGs/fh5lUAiDuKrQontA0Z94IQ==",
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.25.0",
-        "babylon": "^6.17.2",
-        "debug": "^2.2.0",
-        "globals": "^9.0.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
       }
     },
     "babel-types": {
@@ -534,10 +534,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha512-7gcO7CcpZLSylbMXMkKAyVRHMSniXYjDvbFEe6C8yhas7sYFrw/6s+zwuXKpUzrdsNNhQ82HXEiE9MdjSY6uEw==",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
-        "to-fast-properties": "^1.0.1"
+        "babel-runtime": "6.25.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -560,15 +560,15 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.1.tgz",
       "integrity": "sha512-4cJ5bAu1Sr9R8LoGz0hfz6CItwKbGrLmdScSb8A2+v/zssiDX7KTk4rNza4MP4+JpndgHBOm4TlbQmlKaZ9MEA==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "cache-base": "^0.8.4",
-        "class-utils": "^0.3.4",
-        "component-emitter": "^1.2.1",
-        "define-property": "^0.2.5",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3",
-        "pascalcase": "^0.1.1"
+        "arr-union": "3.1.0",
+        "cache-base": "0.8.5",
+        "class-utils": "0.3.5",
+        "component-emitter": "1.2.1",
+        "define-property": "0.2.5",
+        "isobject": "2.1.0",
+        "lazy-cache": "2.0.2",
+        "mixin-deep": "1.2.0",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -576,7 +576,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -584,9 +584,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           }
         },
         "isobject": {
@@ -663,15 +663,15 @@
       "integrity": "sha512-pLoAUdkGfkp6VGbhhNWLtvF5dkWYVY7oSwZa45ZJeTxAipUB9L7n1cx0a/leni10VflrjorZM7Jb5jKxpIYniw==",
       "requires": {
         "bytes": "2.4.0",
-        "content-type": "~1.0.2",
+        "content-type": "1.0.2",
         "debug": "2.6.7",
-        "depd": "~1.1.0",
-        "http-errors": "~1.6.1",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
         "iconv-lite": "0.4.15",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.4.0",
-        "raw-body": "~2.2.0",
-        "type-is": "~1.6.15"
+        "raw-body": "2.2.0",
+        "type-is": "1.6.15"
       },
       "dependencies": {
         "debug": {
@@ -694,12 +694,12 @@
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha512-RaVTblr+OnEli0r/ud8InrU7D+G0y6aJhlxaLa6Pwty4+xoxboF1BsUI45tujvRpbj9dQVoglChqonGAsjEBYg==",
       "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
+        "array-flatten": "2.1.1",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.1.1",
+        "multicast-dns-service-types": "1.1.0"
       }
     },
     "boolbase": {
@@ -712,7 +712,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha512-Dnfc9ROAPrkkeLIUweEbh7LFT9Mc53tO/bbM044rKjhgAEyIGKvKXg97PM/kRizZIfUHaROZIoeEaWao+Unzfw==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -721,17 +721,17 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.2.2.tgz",
       "integrity": "sha512-LsV+Z9xUYWR9XX0fnDceeu4+X+RCZ18P8YHJlgSUEzRjsOFfMl1gjzIg7vfbW6cJg8mfJIuoWpVbgAkimkAWAA==",
       "requires": {
-        "arr-flatten": "^1.0.3",
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^2.1.0",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.1",
+        "snapdragon-node": "2.1.1",
+        "split-string": "2.1.1",
+        "to-regex": "3.0.1"
       }
     },
     "brorand": {
@@ -744,11 +744,11 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha512-MMvWM6jpfsiuzY2Y+pRJvHRac3x3rHWQisWoz1dJaF9qDFsD8HdVxB7MyZKeLKeEt0fEjrXXZ0mxgTHSoJusug==",
       "requires": {
-        "buffer-xor": "^1.0.2",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "inherits": "^2.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.0",
+        "inherits": "2.0.3"
       }
     },
     "browserify-cipher": {
@@ -756,9 +756,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha512-eR/Xnl6GNhMILoylgYn0CXdb5rbDRp3awDF0KXd/S96E+l49E9EWjSmbJPPM03Gj0nX6Ihydv/3wmtml5hnGrw==",
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.0.6",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.0"
       }
     },
     "browserify-des": {
@@ -766,9 +766,9 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha512-8ryPIDvl6sFWCs8M8XOLjysP3BmwTUldIuX5yWHu76zazZpMguxHYFJI+kQ99a0lpuPF5jt+qzkFuMtjgo2xBg==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
       }
     },
     "browserify-rsa": {
@@ -776,8 +776,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha512-+YpEyaLDDvvdzIxQ+cCx73r5YEhS3ANGOkiHdyWqW4t3gdeoNEYjSiQwntbU4Uo2/9yRkpYX3SRFeH+7jc2Duw==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.5"
       }
     },
     "browserify-sign": {
@@ -785,13 +785,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha512-D2ItxCwNtLcHRrOCuEDZQlIezlFyUV/N5IYz6TY1svu1noyThFuthoEjzT8ChZe3UEctqnwmykcPhet3Eiz58A==",
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
       }
     },
     "browserify-zlib": {
@@ -799,7 +799,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
       "requires": {
-        "pako": "~0.2.0"
+        "pako": "0.2.9"
       }
     },
     "buffer": {
@@ -807,9 +807,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha512-DNK4ruAqtyHaN8Zne7PkBTO+dD1Lr0YfTduMqlIyjvQIoztBkUxrvL+hKeLW8NXFKHOq/2upkxuoS9znQ9bW9A==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.2.1",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
       }
     },
     "buffer-indexof": {
@@ -842,16 +842,16 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
       "integrity": "sha512-19t0n7xdoVr5Q08+6sF85YZ9VuvbpVFq5JLm0gcsRmCvTO1Y3duTJGMaOQYf14Ras4o6dEnvoqvjdrUK1tNtgg==",
       "requires": {
-        "collection-visit": "^0.2.1",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.5",
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.1",
-        "set-value": "^0.4.2",
-        "to-object-path": "^0.3.0",
-        "union-value": "^0.2.3",
-        "unset-value": "^0.1.1"
+        "collection-visit": "0.2.3",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "0.3.1",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2",
+        "set-value": "0.4.3",
+        "to-object-path": "0.3.0",
+        "union-value": "0.2.4",
+        "unset-value": "0.1.2"
       }
     },
     "callsite": {
@@ -869,8 +869,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==",
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -885,8 +885,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       },
       "dependencies": {
         "lazy-cache": {
@@ -906,11 +906,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "cheerio": {
@@ -918,22 +918,22 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha512-8/MzidM6G/TgRelkzDG13y3Y9LxBjCb+8yOEZ9+wwq5gVF2w2pV0wmHvjfT0RvuxGyR7UEuK36r+yYMbT4uKgA==",
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.0",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
       }
     },
     "chokidar": {
@@ -941,15 +941,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "cipher-base": {
@@ -957,8 +957,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "class-utils": {
@@ -966,11 +966,11 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz",
       "integrity": "sha512-AXkeIVJMVzRmd6wDGCdtEfFRaE56r+UdBHn1v9gMof4lNs0fnQ2+/l2l3pKCf0x727Ce4a+xQr/psrMotjy0wA==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.2",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -978,7 +978,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -986,9 +986,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           }
         },
         "kind-of": {
@@ -1008,8 +1008,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -1035,9 +1035,9 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
       "integrity": "sha512-V88PJOCqJfsZS45YBELDgmhQkECokQAAr9XR4hT6eFkFsAPsCsk3EoDHSuBPYzygjquGM/0KF4vdwTiQO6lbdw==",
       "requires": {
-        "lazy-cache": "^2.0.1",
-        "map-visit": "^0.1.5",
-        "object-visit": "^0.3.4"
+        "lazy-cache": "2.0.2",
+        "map-visit": "0.1.5",
+        "object-visit": "0.3.4"
       }
     },
     "color-convert": {
@@ -1045,7 +1045,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -1063,7 +1063,7 @@
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
       "integrity": "sha512-4Mi0V7N48B9KzC8Zl/U7wiWuxMFEHf44N3/PSoAvWDu8IOPrddNo1y1tC/kXbP7IvVMhgCFMMNzgKb0pWoin9w==",
       "requires": {
-        "lodash": "^4.5.0"
+        "lodash": "4.17.4"
       }
     },
     "commander": {
@@ -1091,7 +1091,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
       "integrity": "sha512-AbzAwQ9UVfx/PrI746UTEZeM2A5l9Apacq+wHwXrMf2OS23Z3pOJlIrdsbgFqDNua0puLdrLm3hO8nR3fTivWQ==",
       "requires": {
-        "mime-db": ">= 1.29.0 < 2"
+        "mime-db": "1.29.0"
       }
     },
     "compression": {
@@ -1099,13 +1099,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
       "integrity": "sha512-EzpIPZX++rTQylMht3iaYigq2NNJbI/e9VaDzR8sLi8vgOCHpvLT93GuvsGYW2ANEd14Ax2nI1Ydi9L5ykGeig==",
       "requires": {
-        "accepts": "~1.3.3",
+        "accepts": "1.3.3",
         "bytes": "2.5.0",
-        "compressible": "~2.0.10",
+        "compressible": "2.0.11",
         "debug": "2.6.8",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "~1.1.1"
+        "vary": "1.1.1"
       },
       "dependencies": {
         "bytes": {
@@ -1127,7 +1127,7 @@
       "requires": {
         "debug": "2.6.8",
         "finalhandler": "1.0.4",
-        "parseurl": "~1.3.1",
+        "parseurl": "1.3.1",
         "utils-merge": "1.0.0"
       }
     },
@@ -1141,7 +1141,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha512-duS7VP5pvfsNLDvL1O4VOEbw37AI3A4ZUQYemvDlnpGrNu9tprR7BYWpDYwC0Xia0Zxz5ZupdiIrUp0GH1aXfg==",
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "constants-browserify": {
@@ -1189,8 +1189,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha512-7rYnhx2rzljQb/UszJC+KvDO8muh2kJm0meQ+VxlDoEHQ3vnZcaHRLCdIReCasEt3s5gJUy4FkkOw2L7HomsQQ==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-hash": {
@@ -1198,10 +1198,10 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.8"
       }
     },
     "create-hmac": {
@@ -1209,12 +1209,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha512-23osI7H2SH6Zm4g7A7BTM9+3XicGZkemw00eEhrFViR3EdGru+azj2fMKf9J2zWMGO7AfPgYRdIRL96kkdy8QA==",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.8"
       }
     },
     "create-react-class": {
@@ -1222,9 +1222,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
       "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "crypto-browserify": {
@@ -1232,16 +1232,16 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
       "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.13",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.5"
       }
     },
     "css-select": {
@@ -1249,10 +1249,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha512-dUQOBoqdR7QwV90WysXPLXG5LO7nhYBgiWVfxF80DKPF8zx1t/pUd2FYy73emg3zrjtM6dzmYgbHKfV2rxiHQA==",
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "nth-check": "1.0.1"
       }
     },
     "css-what": {
@@ -1265,7 +1265,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "custom-event": {
@@ -1301,8 +1301,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha512-hpr5VSFXGamODSCN6P2zdSBY6zJT7DlcBAHiPIa2PWDvfBqJQntSK0ehUoHoS6HGeSS19dgj7E+1xOjfG3zEtQ==",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -1310,7 +1310,7 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
       "requires": {
-        "is-descriptor": "^1.0.0"
+        "is-descriptor": "1.0.1"
       }
     },
     "defined": {
@@ -1323,12 +1323,12 @@
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha512-7yjqSoVSlJzA4t/VUwazuEagGeANEKB3f/aNI//06pfKgwoCb7f6Q1gETN1sZzYaj6chTQ0AhIwDiPdfOjko4A==",
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "p-map": "1.1.1",
+        "pify": "3.0.0",
+        "rimraf": "2.6.1"
       },
       "dependencies": {
         "pify": {
@@ -1348,8 +1348,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha512-QlJHGiTiOmW4z3EO0qKwjM2Mb+EmOlBHbpC6QgTiXB913NxMKttEuV2SJ+eLA12sMKDg1N8HnncfAtYaNnU+cg==",
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "destroy": {
@@ -1377,9 +1377,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha512-6bFNThpXO1MSkYrHm2SPXvfJQ3h4gChXxj5RToODJGCs7Df79q+KNJAiB71Nut2n50ZLc35NTOPVc7jYPPWwtg==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.0",
+        "randombytes": "2.0.5"
       }
     },
     "dns-equal": {
@@ -1392,8 +1392,8 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.1.1.tgz",
       "integrity": "sha512-m0Z24evP6z/YyeKrB2dQi0MVjAG2MHd4DaPe3kFQPcleFGR/KbrJ1xoRqLE49eaaIglhOSYcXt57m95TXLK1Gw==",
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.1"
       }
     },
     "dns-txt": {
@@ -1401,7 +1401,7 @@
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha512-Ix5PrWjphuSoUXV/Zv5gaFHjnaJtb02F2+Si3Ht9dyJ87+Z/lMmy+dpNHtTGraNK958ndXq2i+GLkWsWHcKaBQ==",
       "requires": {
-        "buffer-indexof": "^1.0.0"
+        "buffer-indexof": "1.1.0"
       }
     },
     "dom-helpers": {
@@ -1414,10 +1414,10 @@
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
       "requires": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "void-elements": "2.0.1"
       }
     },
     "dom-serializer": {
@@ -1425,8 +1425,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha512-Fql7PX6CmQNVmoLfp7DlmvFMIL5cwLbm302SycA2iAMr95t1ITX4ilIsUG75rYtMiVLb4EMC5b2o7ApEpIXROg==",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -1461,7 +1461,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
       "integrity": "sha512-j/nPtjIvPTcloeLUJ3FXpck1Ey6jZEyXx2Xni9GiHrBl56cYnSqOGMNzmzspo+U7+m4zncrzs3a42IYSvOig0A==",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -1469,8 +1469,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "duplexer": {
@@ -1488,13 +1488,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha512-s8oifyiQMQi+n/gJuw37WK3D1aVOWIgj59+DBsg48eJPo34QZWl2cl9kL4SI/W94/AdMFAyXG+QnSzbXQ+iJ1w==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emojis-list": {
@@ -1512,7 +1512,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha512-bl1LAgiQc4ZWr++pNYUdRe/alecaHFeHxIJ/pNciqGdKXghaTCOwKkbKp6ye7pKZGu/GcaSXFk8PBVhgs+dJdA==",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.18"
       }
     },
     "engine.io": {
@@ -1595,10 +1595,10 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
       "integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "object-assign": "^4.0.1",
-        "tapable": "^0.2.5"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
       }
     },
     "ent": {
@@ -1616,16 +1616,16 @@
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
       "integrity": "sha512-64Gr+ozwW9LNQ9YetJ6qHZpLQ9RCYZyVqnuE7XAEfgRsTNTB72v//E9Lp6iNeclXRU0FHywzFRb9kLXMfRyotw==",
       "requires": {
-        "cheerio": "^0.22.0",
-        "function.prototype.name": "^1.0.0",
-        "is-subset": "^0.1.1",
-        "lodash": "^4.17.4",
-        "object-is": "^1.0.1",
-        "object.assign": "^4.0.4",
-        "object.entries": "^1.0.4",
-        "object.values": "^1.0.4",
-        "prop-types": "^15.5.10",
-        "uuid": "^3.0.1"
+        "cheerio": "0.22.0",
+        "function.prototype.name": "1.0.3",
+        "is-subset": "0.1.1",
+        "lodash": "4.17.4",
+        "object-is": "1.0.1",
+        "object.assign": "4.0.4",
+        "object.entries": "1.0.4",
+        "object.values": "1.0.4",
+        "prop-types": "15.5.10",
+        "uuid": "3.1.0"
       }
     },
     "errno": {
@@ -1633,7 +1633,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha512-B6ww/BgkeBIfyIaOKPMW2zteXdAeXSfOTPv6kGhl3luYw4BOTopQ0EjdGFePGdajvBjLQZq12axGLtHnrp+/Pg==",
       "requires": {
-        "prr": "~0.0.0"
+        "prr": "0.0.0"
       }
     },
     "error-ex": {
@@ -1641,7 +1641,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha512-FfmVxYsm1QOFoPI2xQmNnEH10Af42mCxtGrKvS1JfDTXlPLYiAz2T+QpjHPxf+OGniMfWZah9ULAhPoKQ3SEqg==",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "error-stack-parser": {
@@ -1649,7 +1649,7 @@
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
       "integrity": "sha512-xhuSYd8wLgOXwNgjcPeXMPL/IiiA1Huck+OPvClpJViVNNlJVtM41o+1emp7bPvlCJwCatFX2DWc05/DgfbWzA==",
       "requires": {
-        "stackframe": "^0.3.1"
+        "stackframe": "0.3.1"
       }
     },
     "es-abstract": {
@@ -1657,11 +1657,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
       "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1669,9 +1669,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha512-wXsac552n5sYhgVjyFvhXLunXZFPOiT/WgP7hFhUPU5gtaUQpm9OryPwlWQUS3Qptk8iZzY/2T3J62GtC/toSw==",
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "escape-html": {
@@ -1709,7 +1709,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha512-bbB5tEuvC+SuRUG64X8ghvjgiRniuA4WlehWbFnoN4z6TxDXpyX+BMHF7rMgZAqoe+EbyNRUbHN0uuP9phy5jQ==",
       "requires": {
-        "original": ">=0.0.5"
+        "original": "1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -1717,7 +1717,7 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "integrity": "sha512-ALeH0LCygUuJllS9VdUF1JLBxD37VHyxlFonQixBbQQLcO50OV2vIqPb1fRSz5WDv8aqTAnK9EMGGiF4fE6ToA==",
       "requires": {
-        "create-hash": "^1.1.1"
+        "create-hash": "1.1.3"
       }
     },
     "expand-braces": {
@@ -1725,9 +1725,9 @@
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "integrity": "sha512-zOOsEnAhvIxxd0esCNbYG2xerGf46niZ1egS43eV7Fu4t7VIScgPXMcMabCLaPrqkzwvwo6zZipDiX3t0ILF2w==",
       "requires": {
-        "array-slice": "^0.2.3",
-        "array-unique": "^0.2.1",
-        "braces": "^0.1.2"
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
       },
       "dependencies": {
         "array-unique": {
@@ -1740,7 +1740,7 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "integrity": "sha512-EIMHIv2UXHWFY2xubUGKz+hq9hNkENj4Pjvr7h58cmJgpkK2yMlKA8I484f7MSttkzVAy/lL7X9xDaILd6avzA==",
           "requires": {
-            "expand-range": "^0.1.0"
+            "expand-range": "0.1.1"
           }
         },
         "expand-range": {
@@ -1748,8 +1748,8 @@
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "integrity": "sha512-busOHJ0t7t5UcutcyNDqmaDX+1cb0XlqsAUgTlmplVv0rIqBaMcBSZRLlkDm0nxtl8O3o/EvRRrdQ/WnyPERLQ==",
           "requires": {
-            "is-number": "^0.1.1",
-            "repeat-string": "^0.2.2"
+            "is-number": "0.1.1",
+            "repeat-string": "0.2.2"
           }
         },
         "is-number": {
@@ -1769,13 +1769,13 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.8",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -1783,7 +1783,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -1791,9 +1791,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           }
         },
         "kind-of": {
@@ -1808,7 +1808,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       },
       "dependencies": {
         "fill-range": {
@@ -1816,11 +1816,11 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
           "integrity": "sha512-P1WnpaJQ8BQdSEIjEmgyCHm9ESwkO6sMu+0Moa4s0u9B+iQ5M9tBbbCYvWmF7vRvqyMO2ENqC+w4Hev8wErQcg==",
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^1.1.3",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "is-number": {
@@ -1828,7 +1828,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isobject": {
@@ -1844,7 +1844,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -1854,34 +1854,34 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
       "integrity": "sha512-g48YBFQpZMDOGe/l9rOUinTcSBAtHVH17+0iFp/nwIP9Ik5thohP0feDe4M748aCOrlA7mC99mlUlbpxdZcq9w==",
       "requires": {
-        "accepts": "~1.3.3",
+        "accepts": "1.3.3",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.2",
+        "content-type": "1.0.2",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.8",
-        "depd": "~1.1.1",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.0",
-        "finalhandler": "~1.0.4",
+        "depd": "1.1.1",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "finalhandler": "1.0.4",
         "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~1.1.5",
+        "proxy-addr": "1.1.5",
         "qs": "6.5.0",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "send": "0.15.4",
         "serve-static": "1.12.4",
         "setprototypeof": "1.0.3",
-        "statuses": "~1.3.1",
-        "type-is": "~1.6.15",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
         "utils-merge": "1.0.0",
-        "vary": "~1.1.1"
+        "vary": "1.1.1"
       },
       "dependencies": {
         "array-flatten": {
@@ -1911,7 +1911,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "requires": {
-        "is-extendable": "^0.1.0"
+        "is-extendable": "0.1.1"
       }
     },
     "extglob": {
@@ -1919,14 +1919,14 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-1.1.0.tgz",
       "integrity": "sha512-rgYmCk8Xo1pC4hXZOUev0Gg3YLdsyQURt3a8ZI8FOY0+UZ10JD0wtP50zsHUXDySzQLdBW6qZy21iE5ld48AMA==",
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^0.2.5",
-        "expand-brackets": "^2.0.1",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^2.1.0"
+        "array-unique": "0.3.2",
+        "define-property": "0.2.5",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "2.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -1934,7 +1934,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -1942,9 +1942,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           }
         },
         "kind-of": {
@@ -1957,9 +1957,9 @@
           "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-2.1.0.tgz",
           "integrity": "sha512-2sPYBVcwx+cz3ABc3Oe/kovpb1GTrPUyNFsVGvP8Bi58Wv0vR5k1O+m4WMWiwG1K2AVyRacEkXyetulkO9uH6Q==",
           "requires": {
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "regex-not": "^0.1.1"
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "regex-not": "0.1.2"
           },
           "dependencies": {
             "regex-not": {
@@ -1976,7 +1976,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha512-Xhj93RXbMSq8urNCUq4p9l0P6hnySJ/7YNRhYNug0bLOuii7pKO7xQFb5mx9xZXWCar88pLPb805PvUkwrLZpQ==",
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.6.5"
       }
     },
     "fbjs": {
@@ -1984,13 +1984,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
       "integrity": "sha512-D7/UTkrH4z6GLL8sCdWczQOCOOO6bt9flM4yAsJE5WXJ0QLu9tnuj8Db5+qGChTZgiT+O5EM/0FlPzZNhx/suA==",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.14"
       }
     },
     "fetch-mock": {
@@ -1998,9 +1998,9 @@
       "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-5.12.2.tgz",
       "integrity": "sha512-2A2I5awNtv0nJWcjUbfX0Y6GXGQv0J3uUj1h7LpC537X1TYnsU91g81DVcx2ZnTJMSJH45mF8UNjmcf/CS/QvA==",
       "requires": {
-        "glob-to-regexp": "^0.3.0",
-        "node-fetch": "^1.3.3",
-        "path-to-regexp": "^1.7.0"
+        "glob-to-regexp": "0.3.0",
+        "node-fetch": "1.7.2",
+        "path-to-regexp": "1.7.0"
       }
     },
     "figures": {
@@ -2008,8 +2008,8 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -2022,10 +2022,10 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       }
     },
     "finalhandler": {
@@ -2034,12 +2034,12 @@
       "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
       "requires": {
         "debug": "2.6.8",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.1",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       }
     },
     "find-up": {
@@ -2047,8 +2047,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "for-each": {
@@ -2056,7 +2056,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha512-EZEij37gJU2yEqysbZ2EcCrEtROFxG+qT1uTVfMnwnHsz9Z1yqkuSmZaYzyLY6P1VzlVPzP2C5HfUSC0CyxcMw==",
       "requires": {
-        "is-function": "~1.0.0"
+        "is-function": "1.0.1"
       }
     },
     "for-in": {
@@ -2069,7 +2069,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -2082,7 +2082,7 @@
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha512-YAF05v8+XCxAyHOdiiAmHdgCVPrWO8X744fYIPtBciIorh5LndWfi1gjeJ16sTbJhzek9kd+j3YByhohtz5Wmg==",
       "requires": {
-        "samsam": "1.x"
+        "samsam": "1.2.1"
       }
     },
     "forwarded": {
@@ -2095,7 +2095,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -2108,7 +2108,7 @@
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha512-05cXDIwNbFaoFWaz5gNHlUTbH5whiss/hr/ibzPd4MH3cR4w0ZKeIPiVdbyJurg3O5r/Bjpvn9KOb1/rPMf3nA==",
       "requires": {
-        "null-check": "^1.0.0"
+        "null-check": "1.0.0"
       }
     },
     "fs.realpath": {
@@ -2122,8 +2122,8 @@
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2145,8 +2145,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -2157,7 +2157,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2211,7 +2211,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -2224,14 +2224,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -2239,12 +2239,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -2257,7 +2257,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -2265,7 +2265,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -2273,8 +2273,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -2290,7 +2290,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -2302,7 +2302,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -2313,8 +2313,8 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -2322,7 +2322,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -2342,9 +2342,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2352,16 +2352,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -2369,8 +2369,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -2383,8 +2383,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -2392,10 +2392,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -2411,7 +2411,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -2429,8 +2429,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -2448,10 +2448,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2466,13 +2466,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -2480,7 +2480,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -2516,9 +2516,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -2526,14 +2526,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -2546,13 +2546,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -2565,7 +2565,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -2588,9 +2588,9 @@
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
       "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.0",
-        "is-callable": "^1.1.3"
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "is-callable": "1.1.3"
       }
     },
     "get-caller-file": {
@@ -2613,12 +2613,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -2626,8 +2626,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -2635,7 +2635,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-to-regexp": {
@@ -2648,8 +2648,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha512-/4AybdwIDU4HkCUbJkZdWpe4P6vuw/CUtu+0I1YlLIPe7OlUO7KNJ+q/rO70CW2/NW6Jc6I62++Hzsf5Alu6rQ==",
       "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       }
     },
     "globals": {
@@ -2662,11 +2662,11 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "graceful-fs": {
@@ -2684,7 +2684,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha512-8wpov6mGFPJ/SYWGQIFo6t0yuNWoO9MkSq3flX8LhiGmbIUhDETp9knPMcIm0Xig1ybWsw6gq2w0gCz1JHD+Qw==",
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.0"
       }
     },
     "has-ansi": {
@@ -2692,7 +2692,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary": {
@@ -2725,9 +2725,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
       "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
       "requires": {
-        "get-value": "^2.0.3",
-        "has-values": "^0.1.4",
-        "isobject": "^2.0.0"
+        "get-value": "2.0.6",
+        "has-values": "0.1.4",
+        "isobject": "2.1.0"
       },
       "dependencies": {
         "isobject": {
@@ -2750,7 +2750,7 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "hash.js": {
@@ -2758,8 +2758,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "history": {
@@ -2767,11 +2767,11 @@
       "resolved": "https://registry.npmjs.org/history/-/history-4.6.3.tgz",
       "integrity": "sha512-ti4fScEW6avdQk4vdFqm0HRW29cWmB0RTUMIsC4/5sxZM1FHRoyyDjpMyhR93RJ3dPc2FhvlpEsnGndDo/KGyw==",
       "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.0.0",
-        "value-equal": "^0.2.0",
-        "warning": "^3.0.0"
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "resolve-pathname": "2.1.0",
+        "value-equal": "0.2.1",
+        "warning": "3.0.0"
       }
     },
     "hmac-drbg": {
@@ -2779,9 +2779,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoist-non-react-statics": {
@@ -2799,10 +2799,10 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
+        "inherits": "2.0.3",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "wbuf": "1.7.2"
       }
     },
     "html-entities": {
@@ -2815,12 +2815,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha512-RSOwLNCnCLDRB9XpSfCzsLzzX8COezhJ3D4kRBNWh0NC/facp1hAMmM8zD7kC01My8vD6lGEbPMlbRW/EwGK5w==",
       "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.5.1",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       }
     },
     "http-deceiver": {
@@ -2836,7 +2836,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": ">= 1.3.1 < 2"
+        "statuses": "1.3.1"
       }
     },
     "http-proxy": {
@@ -2844,8 +2844,8 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha512-mVtRyhMoqY5UCrvvqTTIfQPgRO+dDR1qHbuBYk8fjUpA51KUzesT++tRQSdiEhjBBobO4PCnP4ITc/BFsBkm6w==",
       "requires": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "1.x.x"
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -2853,10 +2853,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha512-JtH3UZju4oXDdca28/kknbm/CFmt35vy0YV0PNOMWWWpn3rT9WV95IXN451xwBGSjy9L0Cah1O9TCMytboLdfw==",
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^3.1.0",
-        "lodash": "^4.17.2",
-        "micromatch": "^2.3.11"
+        "http-proxy": "1.16.2",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11"
       },
       "dependencies": {
         "arr-diff": {
@@ -2864,7 +2864,7 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -2877,9 +2877,9 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "expand-brackets": {
@@ -2887,7 +2887,7 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -2895,7 +2895,7 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -2910,7 +2910,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "kind-of": {
@@ -2918,7 +2918,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         },
         "micromatch": {
@@ -2926,19 +2926,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
           },
           "dependencies": {
             "is-extglob": {
@@ -2951,7 +2951,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
               "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
               }
             }
           }
@@ -2978,7 +2978,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha512-aqwDFWSgSgfRaEwao5lg5KEcVd/2a+D1rvoG7NdilmYz0NwRk6StWpWdz/Hpk34MKPpx7s8XxUqimfcQK6gGlg==",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexof": {
@@ -2991,8 +2991,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -3005,7 +3005,7 @@
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
       "integrity": "sha512-DzGfTasXPmwizQP4XV2rR6r2vp8TjlOpMnJqG9Iy2i1pl1lkZdZj5rSpIc7YFGX2nS46PPgAGEyT+Q5hE2FB2g==",
       "requires": {
-        "meow": "^3.3.0"
+        "meow": "3.7.0"
       }
     },
     "interpret": {
@@ -3018,7 +3018,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha512-FUiAFCOgp7bBzHfa/fK+Uc/vqywvdN9Wg3CiTprLcE630mrhxjDS5MlBkHzeI6+bC/6bq9VX/hxBt05fPAT5WA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "invert-kv": {
@@ -3041,7 +3041,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3049,7 +3049,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -3064,7 +3064,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.9.0"
       }
     },
     "is-buffer": {
@@ -3077,7 +3077,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha512-C2wz7Juo5pUZTFQVer9c+9b4qw3I5T/CHQxQyhVu7BJel6C22FmsLIWsdseYyOw6xz9Pqy9eJWSkQ7+3iN1HVw==",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -3090,7 +3090,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3098,7 +3098,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -3113,9 +3113,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
       "integrity": "sha512-G3fFVFTqfaqu7r4YuSBHKBAuOaLz8Sy7ekklUpFEliaLMP1Y2ZjoN9jS62YWCAPQrQpMUQSitRlrzibbuCZjdA==",
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3135,7 +3135,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -3153,7 +3153,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha512-e+gU0KGrlbqjEcV80SAqg4g7PQYOm3/IrdwAJ+kPwHqGhLKhtuTJGGxGtrsc8RXlHt2A8Vlnv+79Vq2B1GQasg==",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -3161,7 +3161,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-function": {
@@ -3174,7 +3174,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -3189,7 +3189,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3197,7 +3197,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -3207,7 +3207,7 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
       "integrity": "sha512-yIhxkKCK7pZnj48WBvaTQ36Or7PymGYqmZrSNqkrhmU3pakkp2TWhuN7hH25bqJgH+Xq4IZ3QNd3+QVshldEHA==",
       "requires": {
-        "is-number": "^3.0.0"
+        "is-number": "3.0.0"
       }
     },
     "is-path-cwd": {
@@ -3220,7 +3220,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha512-XSig+5QTx0ReXCURjvzGsLUFT8V36AjyVkc6axI1r5QT3BMVR0MptnXBNU7iyfn2aQIgm8/vP4h58RVIsL7rEw==",
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.0"
       }
     },
     "is-path-inside": {
@@ -3228,7 +3228,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha512-WdiHWLVPHbn+QOQdJXqJS7TtArj7yXvKb8ZyFZ7AaIuW7KOfLLyR5glFAR+b1Q6PhSOTL8lpQvIoV2klU0nE9g==",
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-object": {
@@ -3236,7 +3236,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -3254,7 +3254,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha512-WQgPrEkb1mPCWLSlLFuN1VziADSixANugwSkJfPRR73FNWIQQN+tR/t1zWfyES/Y9oag/XBtVsahFdfBku3Kyw==",
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-stream": {
@@ -3302,8 +3302,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.2",
+        "whatwg-fetch": "2.0.3"
       }
     },
     "js-cookie": {
@@ -3326,7 +3326,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json3": {
@@ -3354,33 +3354,33 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.7.0.tgz",
       "integrity": "sha512-SqRag/QWoS0GQbUmHQTlzD/6xDXDW1r7gSFSV01kHW+yewtyXDHYj4ZeWjSlh0Dp5ncEjGbTEe6Bk56yZ5gGDQ==",
       "requires": {
-        "bluebird": "^3.3.0",
-        "body-parser": "^1.16.1",
-        "chokidar": "^1.4.1",
-        "colors": "^1.1.0",
-        "combine-lists": "^1.0.0",
-        "connect": "^3.6.0",
-        "core-js": "^2.2.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.0",
-        "expand-braces": "^0.1.1",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "http-proxy": "^1.13.0",
-        "isbinaryfile": "^3.0.0",
-        "lodash": "^3.8.0",
-        "log4js": "^0.6.31",
-        "mime": "^1.3.4",
-        "minimatch": "^3.0.2",
-        "optimist": "^0.6.1",
-        "qjobs": "^1.1.4",
-        "range-parser": "^1.2.0",
-        "rimraf": "^2.6.0",
-        "safe-buffer": "^5.0.1",
+        "bluebird": "3.5.0",
+        "body-parser": "1.17.2",
+        "chokidar": "1.7.0",
+        "colors": "1.1.2",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.3",
+        "core-js": "2.5.0",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "http-proxy": "1.16.2",
+        "isbinaryfile": "3.0.2",
+        "lodash": "3.10.1",
+        "log4js": "0.6.38",
+        "mime": "1.3.6",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.1.5",
+        "range-parser": "1.2.0",
+        "rimraf": "2.6.1",
+        "safe-buffer": "5.1.1",
         "socket.io": "1.7.3",
-        "source-map": "^0.5.3",
+        "source-map": "0.5.6",
         "tmp": "0.0.31",
-        "useragent": "^2.1.12"
+        "useragent": "2.2.1"
       },
       "dependencies": {
         "core-js": {
@@ -3400,8 +3400,8 @@
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
       "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "requires": {
-        "fs-access": "^1.0.0",
-        "which": "^1.2.1"
+        "fs-access": "1.0.1",
+        "which": "1.3.0"
       }
     },
     "karma-tap": {
@@ -3419,11 +3419,11 @@
       "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.4.tgz",
       "integrity": "sha512-yo884hUUHQJ3dTOyX/3t1v6agvBHzVdznB6818fAwXpJL5wPCWKDKg3ovYYwZBe4Tr0f2DGqrQ8K1k9WRO3jIA==",
       "requires": {
-        "async": "~0.9.0",
-        "loader-utils": "^0.2.5",
-        "lodash": "^3.8.0",
-        "source-map": "^0.1.41",
-        "webpack-dev-middleware": "^1.0.11"
+        "async": "0.9.2",
+        "loader-utils": "0.2.17",
+        "lodash": "3.10.1",
+        "source-map": "0.1.43",
+        "webpack-dev-middleware": "1.12.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -3431,10 +3431,10 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
           }
         },
         "lodash": {
@@ -3447,7 +3447,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -3457,7 +3457,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
       "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.5"
       }
     },
     "lazy-cache": {
@@ -3465,7 +3465,7 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
       "integrity": "sha512-7vp2Acd2+Kz4XkzxGxaB1FWOi8KjWIWsgdfD5MCb86DWvlLqhRPM+d6Pro3iNEL5VT9mstz5hKAlcd+QR6H3aA==",
       "requires": {
-        "set-getter": "^0.1.0"
+        "set-getter": "0.1.0"
       }
     },
     "lcid": {
@@ -3473,7 +3473,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "load-json-file": {
@@ -3481,11 +3481,11 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "loader-runner": {
@@ -3498,9 +3498,9 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha512-gkD9aSEG9UGglyPcDJqY9YBTUtCLKaBK6ihD2VP1d1X60lTfFspNZNulGBBbUZLkPygy4LySYHyxBpq+VhjObQ==",
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
+        "big.js": "3.1.3",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
       }
     },
     "lodash": {
@@ -3578,8 +3578,8 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "integrity": "sha512-Cd+klbx7lkiaamEId9/0odHxv/PFHDz2E12kEfd6/CzIOZD084DzysASR/Dot4i1dYPBQKC3r2XIER+dfbLOmw==",
       "requires": {
-        "readable-stream": "~1.0.2",
-        "semver": "~4.3.3"
+        "readable-stream": "1.0.34",
+        "semver": "4.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -3592,10 +3592,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3625,7 +3625,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha512-iG/U770U9HaHmy0u+fSyxSIclZ3d9WPFtGjV2drWW0SthBnQ1Fa/SCKIaGLAVwYzrBGEPx9gen047er+MCUgnQ==",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -3633,8 +3633,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==",
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lru-cache": {
@@ -3657,8 +3657,8 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
       "integrity": "sha512-zdmJBFvvVR/H5wCfsCP7XxSLp+346yAZ30Wy2OsQLcH19OVGMWa3Ms9quO00lj9ybsySu3gKOINNgICb4Zqauw==",
       "requires": {
-        "lazy-cache": "^2.0.1",
-        "object-visit": "^0.3.4"
+        "lazy-cache": "2.0.2",
+        "object-visit": "0.3.4"
       }
     },
     "media-typer": {
@@ -3671,8 +3671,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha512-cda4JKCxReDXFXRqOHPQscuIYg1PvxbE2S2GP45rnwfEK+vZaXC8C1OFvdHIbgw0DLzowXGVoxLaAmlgRy14GQ==",
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.4",
+        "readable-stream": "2.3.3"
       }
     },
     "meow": {
@@ -3680,16 +3680,16 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha512-TNdwZs0skRlpPpCUK25StC4VH+tP5GgeY1HQOOGP+lQ2xtdkN2VtT/5tiX9k3IWpkBPV9b3LsAWXn4GGi/PrSA==",
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -3714,19 +3714,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.0.4.tgz",
       "integrity": "sha512-W07uHmC2/7xleHWcYgg4iASgcUSY9TCBnap3gAn+331X7hMQKyRDGzcHzMsadQKa5KNcM/55hFocVggIyTuVFQ==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.2.2",
-        "define-property": "^1.0.0",
-        "extend-shallow": "^2.0.1",
-        "extglob": "^1.1.0",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^4.0.0",
-        "nanomatch": "^1.2.0",
-        "object.pick": "^1.2.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.2.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "extglob": "1.1.0",
+        "fragment-cache": "0.2.1",
+        "kind-of": "4.0.0",
+        "nanomatch": "1.2.0",
+        "object.pick": "1.2.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
       }
     },
     "miller-rabin": {
@@ -3734,8 +3734,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha512-aaZr5VprJSt03eVBJEsG+LOI2ccb/j+DXrnme/z/2M2+K9TRM7IY0+Csko/8dYF3XlUHvgPhrcDZfOAHXYqiZg==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -3753,7 +3753,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
       "integrity": "sha512-YjTLbZxlgVrR0Gv3KxaqEcTDMoxI+kjRw8box2aRPm0IDtIqP6hC6pv5F2ONy7UcgTtSQE6zAqkZE7jDP0gb1g==",
       "requires": {
-        "mime-db": "~1.29.0"
+        "mime-db": "1.29.0"
       }
     },
     "min-document": {
@@ -3761,7 +3761,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
       "requires": {
-        "dom-walk": "^0.1.0"
+        "dom-walk": "0.1.1"
       }
     },
     "minimalistic-assert": {
@@ -3779,7 +3779,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -3792,8 +3792,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
       "integrity": "sha512-MRoPJqsNaIXa7MRO/hKVpDvS4KW7hqLuGGOqC2KLUCY0nVRcTp2BMW8i+AJM7Dd7PQREx/gF1Eo2s5NrE4XzQg==",
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^0.1.1"
+        "for-in": "1.0.2",
+        "is-extendable": "0.1.1"
       }
     },
     "mkdirp": {
@@ -3814,7 +3814,7 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
       "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
       "requires": {
-        "moment": ">= 2.9.0"
+        "moment": "2.18.1"
       }
     },
     "ms": {
@@ -3827,8 +3827,8 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
       "integrity": "sha512-SBEb6yEIJ0rvDuo7fZdrtTVhPkHyr8U991ELe7k7KcdrG1lV/oA8VkoTzJNAkA3XRspih5zy2mso4BJ+VSAcTw==",
       "requires": {
-        "dns-packet": "^1.0.1",
-        "thunky": "^0.1.0"
+        "dns-packet": "1.1.1",
+        "thunky": "0.1.0"
       }
     },
     "multicast-dns-service-types": {
@@ -3847,18 +3847,18 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.0.tgz",
       "integrity": "sha512-w8BXr7QBQy9M5X+41BiGRnAd/YNJtI8v9C1CHG3xQ0QJxkCSf3a2U/HvUnJHGR9bXQs790Os9FtoC11jTLXPIQ==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "is-extglob": "^2.1.1",
-        "is-odd": "^1.0.0",
-        "kind-of": "^4.0.0",
-        "object.pick": "^1.2.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "is-extglob": "2.1.1",
+        "is-odd": "1.0.0",
+        "kind-of": "4.0.0",
+        "object.pick": "1.2.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
       }
     },
     "native-promise-only": {
@@ -3876,10 +3876,10 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.0.1.tgz",
       "integrity": "sha512-NbvXPsKMJn+0q/FqnYTAXOkGaAC2ns87ZR5NvyuY2O4puEVriY8uLHoexKouKsWPKR9iSSAMyYRlCDfyAX/vqQ==",
       "requires": {
-        "formatio": "^1.2.0",
-        "just-extend": "^1.1.22",
-        "lolex": "^1.6.0",
-        "path-to-regexp": "^1.7.0"
+        "formatio": "1.2.0",
+        "just-extend": "1.1.22",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0"
       },
       "dependencies": {
         "lolex": {
@@ -3894,8 +3894,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
       "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-forge": {
@@ -3908,28 +3908,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
       "integrity": "sha512-E2nYZga33lhJO5hQS9WEsEWzUYh9W3HVAC44VSJTd+GHFibroFAoWS9xhQtvVS48TX5SHiodoxJ2QUXxtTm//g==",
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.1.4",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.1",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
         "https-browserify": "0.0.1",
-        "os-browserify": "^0.2.0",
+        "os-browserify": "0.2.1",
         "path-browserify": "0.0.0",
-        "process": "^0.11.0",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.0.5",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.3.1",
-        "string_decoder": "^0.10.25",
-        "timers-browserify": "^2.0.2",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.3",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "2.0.3",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.10.3",
+        "url": "0.11.0",
+        "util": "0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -3950,10 +3950,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "4.3.6",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -3961,20 +3961,20 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.0.2"
       }
     },
     "normalize.css": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-4.1.1.tgz",
-      "integrity": "sha512-9CN4CpnFPuU9vnH4uNiS8J6DFsemK1OD4jW7vqNSv67TQurzOEBfD6kOKoIGoF93c5mmzBbKZ3vR1OXckLjSsw=="
+      "integrity": "sha1-TwsdWiNTgyUrBNhWa4Zsxfytnww="
     },
     "nth-check": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha512-lTD1gl0OIJzVFadNdZ1Tc+Z1vqRlYr6syYgCvhtoOxl5T3c8mufKaJ0XEiaJ+HQSYbCaSH/NP5m5p+so/nTOOA==",
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "null-check": {
@@ -4002,9 +4002,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -4012,7 +4012,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -4020,9 +4020,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4037,7 +4037,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -4062,7 +4062,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
       "integrity": "sha512-6QNyX7uTuwqxP7pmDBqgBDKdmZws1rXriUyXM5KG6+7J0aYRuuAGoc636IGdLzgOL77WUwL+EpoTJrEHwWsyOA==",
       "requires": {
-        "isobject": "^2.0.0"
+        "isobject": "2.1.0"
       },
       "dependencies": {
         "isobject": {
@@ -4080,9 +4080,9 @@
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "integrity": "sha512-RUMl4JcrbyFSPF2x7BQWr3nbHLqmy4732SWc2brBe89YLHZoZW/AFWKndkt0LFumLJPbsX3xb0PukBFBwCcmSw==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.0",
-        "object-keys": "^1.0.10"
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "object-keys": "1.0.11"
       }
     },
     "object.entries": {
@@ -4090,10 +4090,10 @@
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
       "integrity": "sha512-mGYNJ4IFu7v8qEya1mtMfOlOLE603v+UTSl7fL4yzoTwGXGnMBoxz6WZo0fbWY7PebTd+gdFqAtU4XmNaEHEVg==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.0",
+        "function-bind": "1.1.0",
+        "has": "1.0.1"
       }
     },
     "object.omit": {
@@ -4101,8 +4101,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -4110,7 +4110,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
       "integrity": "sha512-ZdCZqyVT6QaH9vsov6NehKz1YvPFObBmxFaUSrEJ+oLF27jszHbPezP9fRKM/Vmh/losgA4+US8/YYiz6/JysQ==",
       "requires": {
-        "isobject": "^2.1.0"
+        "isobject": "2.1.0"
       },
       "dependencies": {
         "isobject": {
@@ -4128,10 +4128,10 @@
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "integrity": "sha512-j8kQn+slWQe1yBFI03FUchGaE5nlK2KLbxV86hM5eCz+pTE9JB4NOGivv/o1wPELIuag7VSfo2vcNQwZjIsYlA==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.0",
+        "function-bind": "1.1.0",
+        "has": "1.0.1"
       }
     },
     "obuf": {
@@ -4157,7 +4157,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "opn": {
@@ -4165,8 +4165,8 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha512-iPBWbPP4OEOzR1xfhpGLDh+ypKBOygunZhM9jBtA7FS5sKjEiMZw0EFb82hnDOmTZX90ZWLoZKUza4cVt8MexA==",
       "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
       }
     },
     "optimist": {
@@ -4174,8 +4174,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "options": {
@@ -4188,7 +4188,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
       "integrity": "sha512-uSGdLwcsvxUcF9GuxWpO3Aji9aWbuvUvVkjOgc1QF5FUxa1dh3uwLW7IyBilw5teR3odBp16PPO2tGKyCsDdfw==",
       "requires": {
-        "url-parse": "1.0.x"
+        "url-parse": "1.0.5"
       },
       "dependencies": {
         "url-parse": {
@@ -4196,8 +4196,8 @@
           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
           "integrity": "sha512-NoHik+qrUN108kCFLzM/7M6+GO1BohhYsi1lHV5lkB2VmzIl8fdGTmW6uTy3ivNlO5cu/YLq1JcVc0RKT6SyzQ==",
           "requires": {
-            "querystringify": "0.0.x",
-            "requires-port": "1.0.x"
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
           }
         }
       }
@@ -4212,7 +4212,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -4235,11 +4235,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha512-YWem2SHsJdkQViMUKu+7enuZvLZmrIneY6FATMbuZ/CgH7UVoAE/8A1kvdClCkuyNjaYtLsczBaRUNWel/vvtw==",
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.9.1",
+        "browserify-aes": "1.0.6",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.0",
+        "pbkdf2": "3.0.13"
       }
     },
     "parse-glob": {
@@ -4247,10 +4247,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -4265,7 +4265,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-ms": {
@@ -4278,7 +4278,7 @@
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha512-v38ZjVbinlZ2r1Rz06WUZEnGoSRcEGX+roMsiWjHeAe23s2qlQUyfmsPQZvh7d8l0E8AZzTIO/RkUr00LfkSiA==",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseqs": {
@@ -4286,7 +4286,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha512-B3Nrjw2aL7aI4TDujOzfA4NsEc4u1lVcIRE0xesutH8kjeWF70uk+W5cBlIQx04zUH9NTBvuN36Y9xLRPK6Jjw==",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -4294,7 +4294,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha512-ijhdxJu6l5Ru12jF0JvzXVPvsC+VibqeaExlNoMhWN6VQ79PGjkmc7oA4W1lp00sFkNyj0fx6ivPLdV51/UMog==",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -4317,7 +4317,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -4355,9 +4355,9 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pbkdf2": {
@@ -4365,11 +4365,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
       "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.8"
       }
     },
     "pify": {
@@ -4387,7 +4387,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plur": {
@@ -4400,9 +4400,9 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha512-ULY4nnWaco7FwsQh6V0Gm0wTvMcCAT3GIsadt8Gqrrc4XJSXkC9XLHzAE1oMAtVS68jnrAjDypYfVPVP1JeTmA==",
       "requires": {
-        "async": "^1.5.2",
-        "debug": "^2.2.0",
-        "mkdirp": "0.5.x"
+        "async": "1.5.2",
+        "debug": "2.6.8",
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "async": {
@@ -4427,9 +4427,9 @@
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
       "integrity": "sha512-H2enpsxzDhuzRl3zeSQpQMirn8dB0Z/gxW96j06tMfTviUWvX14gjKb7qd1gtkUyYhDPuoNe00K5PqNvy2oQNg==",
       "requires": {
-        "is-finite": "^1.0.1",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
+        "is-finite": "1.0.2",
+        "parse-ms": "1.0.1",
+        "plur": "1.0.0"
       }
     },
     "process": {
@@ -4447,7 +4447,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "prop-types": {
@@ -4455,8 +4455,8 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
       "integrity": "sha512-vCFzoUFaZkVNeFkhK1KbSq4cn97GDrpfBt9K2qLkGnPAEFhEv3M61Lk5t+B7c0QfMLWo0fPkowk/4SuXerh26Q==",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1"
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1"
       }
     },
     "proxy-addr": {
@@ -4464,7 +4464,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
       "integrity": "sha512-av1MQ5vwTiMICwU75KSf/vJ6a+AXP0MtP+aYBqm2RFlire7BP6sWlfOLc8+6wIQrywycqSpJWm5zNkYFkRARWA==",
       "requires": {
-        "forwarded": "~0.1.0",
+        "forwarded": "0.1.0",
         "ipaddr.js": "1.4.0"
       }
     },
@@ -4478,11 +4478,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha512-jypsKydIz+OGpL8/PLPlYtlOP8Sqx54lQa+46srROOvUj02byeX+7RoZH49emN9OZSFiKohPLDMTzWK4JNR5Zg==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.5"
       }
     },
     "punycode": {
@@ -4495,7 +4495,7 @@
       "resolved": "https://registry.npmjs.org/pure-render-decorator/-/pure-render-decorator-1.2.1.tgz",
       "integrity": "sha512-oMRKTwu2xPqu4GC1GON/dWr0nEeg/fegBsutlymIjJKZkgfBJyAwsACzZjdGuKuWi9gMp71IDFybNQ8GmWsU+Q==",
       "requires": {
-        "fbjs": "^0.8.0"
+        "fbjs": "0.8.14"
       }
     },
     "qjobs": {
@@ -4528,8 +4528,8 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       }
     },
     "randombytes": {
@@ -4537,7 +4537,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "range-parser": {
@@ -4572,11 +4572,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "create-react-class": "15.6.2",
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
       }
     },
     "react-addons-css-transition-group": {
@@ -4584,7 +4584,7 @@
       "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.6.0.tgz",
       "integrity": "sha512-D8YTZGv/pXCqk0jzxca3uL3SJRnqcSaVwcGUi13zAUHa43FRlN9XaaJuqMRvUSls7zrD+WYi0T4WeWf4y+5ftw==",
       "requires": {
-        "react-transition-group": "^1.2.0"
+        "react-transition-group": "1.2.0"
       }
     },
     "react-addons-test-utils": {
@@ -4597,7 +4597,7 @@
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-5.5.3.tgz",
       "integrity": "sha512-bNtx7p5q1dRh/JGofOYY3IXTCxs6vLo4BJXrU/PQL5m1LjHS3LaMHGWcg5vykCq8srjFx78ub31/tF8SEM9iLQ==",
       "requires": {
-        "prop-types": "^15.5.10"
+        "prop-types": "15.5.10"
       }
     },
     "react-deep-force-update": {
@@ -4610,10 +4610,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
       }
     },
     "react-dropzone": {
@@ -4621,8 +4621,8 @@
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.2.13.tgz",
       "integrity": "sha512-kqpt0Up4GZZFoz4WvBTVzMmVDUZFoGRKDXeyV+baWXZx8Gt0CZmOtV7BSMF1JaBihx6mwy+rfYVNnOKB2hrY9Q==",
       "requires": {
-        "attr-accept": "^1.0.3",
-        "prop-types": "^15.5.7"
+        "attr-accept": "1.1.3",
+        "prop-types": "15.5.10"
       }
     },
     "react-hot-loader": {
@@ -4630,12 +4630,12 @@
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.0.0-beta.7.tgz",
       "integrity": "sha512-p2VbPsRrbiwR0JTyIonka1PcoEbF7Y9q/7tsCsvgYmu8MkBCdokqV7ZPB7wbNhGX2lmnmoUb534N2sYntrYNrA==",
       "requires": {
-        "babel-template": "^6.7.0",
-        "global": "^4.3.0",
-        "react-deep-force-update": "^2.0.1",
-        "react-proxy": "^3.0.0-alpha.0",
-        "redbox-react": "^1.3.6",
-        "source-map": "^0.4.4"
+        "babel-template": "6.25.0",
+        "global": "4.3.2",
+        "react-deep-force-update": "2.1.0",
+        "react-proxy": "3.0.0-alpha.1",
+        "redbox-react": "1.5.0",
+        "source-map": "0.4.4"
       },
       "dependencies": {
         "source-map": {
@@ -4643,7 +4643,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -4653,7 +4653,7 @@
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
       "integrity": "sha512-uyPHKDJ99eBf/wTi768z176I8+c2NvGG5wKdctvHJO5XyZl/brIiwDQ+HBA8Zag5nDdTICYxdBafxBiUxJARrQ==",
       "requires": {
-        "lodash": "^4.6.1"
+        "lodash": "4.17.4"
       }
     },
     "react-redux": {
@@ -4661,12 +4661,12 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
       "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
       "requires": {
-        "hoist-non-react-statics": "^2.2.1",
-        "invariant": "^2.0.0",
-        "lodash": "^4.2.0",
-        "lodash-es": "^4.2.0",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.5.10"
+        "hoist-non-react-statics": "2.2.2",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.5.10"
       }
     },
     "react-router": {
@@ -4674,13 +4674,13 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.1.2.tgz",
       "integrity": "sha512-VyM87OP+GkijVkkOXJw39A9fKtFelLoZYYDxtELhpZefjYatxI2SUxZcImo/9Tv52rR9UnNJBPSBpVRQMdvi8A==",
       "requires": {
-        "history": "^4.6.0",
-        "hoist-non-react-statics": "^1.2.0",
-        "invariant": "^2.2.2",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.5.3",
-        "prop-types": "^15.5.4",
-        "warning": "^3.0.0"
+        "history": "4.6.3",
+        "hoist-non-react-statics": "1.2.0",
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.5.10",
+        "warning": "3.0.0"
       },
       "dependencies": {
         "hoist-non-react-statics": {
@@ -4695,10 +4695,10 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.1.2.tgz",
       "integrity": "sha512-CU6pFlpfvIj/xi36rZAbUiN0x39241q+d5bAfJJLtlEqlM62F3zgyv5aERH9zesmKqyDBBp2kd85rkq9Mo/iNQ==",
       "requires": {
-        "history": "^4.5.1",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.5.4",
-        "react-router": "^4.1.1"
+        "history": "4.6.3",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.5.10",
+        "react-router": "4.1.2"
       }
     },
     "react-test-renderer": {
@@ -4706,8 +4706,8 @@
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.1.tgz",
       "integrity": "sha512-jflbohN8XxJJ91ItKcAFy7B3GE9aLdyifV6w4qcsRcLpWTmVEAZ33h5MmfHPKhGli6FoPZM5VC1/Xnu1TPCqSw==",
       "requires": {
-        "fbjs": "^0.8.9",
-        "object-assign": "^4.1.0"
+        "fbjs": "0.8.14",
+        "object-assign": "4.1.1"
       }
     },
     "react-transition-group": {
@@ -4715,11 +4715,11 @@
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.0.tgz",
       "integrity": "sha512-XFJMM1KMpEne6GLkDTnSjFzit6qnozJtMXfDnwJoPYbgXn9E+t3Z6x+VoYncOu+snQdv9KHsE93EcFQf8x9R9Q==",
       "requires": {
-        "chain-function": "^1.0.0",
-        "dom-helpers": "^3.2.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.5.6",
-        "warning": "^3.0.0"
+        "chain-function": "1.0.0",
+        "dom-helpers": "3.2.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.5.10",
+        "warning": "3.0.0"
       }
     },
     "read-pkg": {
@@ -4727,9 +4727,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -4737,8 +4737,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -4746,13 +4746,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -4760,10 +4760,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha512-LgQ8mdp6hbxJUZz27qxVl7gmFM/0DfHRO52c5RUbKAgMvr81tour7YYWW1JYNmrXyD/o0Myy9/DC3fUYkqnyzg==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "redbox-react": {
@@ -4771,10 +4771,10 @@
       "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.5.0.tgz",
       "integrity": "sha512-mdxArOI3sF8K5Nay5NG+lv/VW516TbXjjd4h1wcV1Iy4IMDQPnCayjoQXBAycAFSME4nyXRUXCjHxsw2rYpVRw==",
       "requires": {
-        "error-stack-parser": "^1.3.6",
-        "object-assign": "^4.0.1",
-        "prop-types": "^15.5.4",
-        "sourcemapped-stacktrace": "^1.1.6"
+        "error-stack-parser": "1.3.6",
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10",
+        "sourcemapped-stacktrace": "1.1.7"
       }
     },
     "redent": {
@@ -4782,8 +4782,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g==",
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "redux": {
@@ -4791,10 +4791,10 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.0.4"
       }
     },
     "redux-mock-store": {
@@ -4822,8 +4822,8 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha512-mD03Qv3Lb7ncwijS5zPvJUIrIXA1XBrxIuB6/XoesvWlyJBNCk7WZa9fCnIOpTKzd6C1L+rpaxrr6t0CYFDQ+Q==",
       "requires": {
-        "is-equal-shallow": "^0.1.3",
-        "is-primitive": "^2.0.0"
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
       }
     },
     "regex-not": {
@@ -4831,7 +4831,7 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
       "integrity": "sha512-bZ6ng7U/JpG63F9+br3N+dh8QsE1Jm24CEXfUir8lyvZRYZsbQyNy5gflhttrAlmjMtE1JTSKQCx5aVGQGWRKA==",
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -4854,7 +4854,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "require-directory": {
@@ -4877,7 +4877,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-pathname": {
@@ -4895,7 +4895,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
       "requires": {
-        "through": "~2.3.4"
+        "through": "2.3.8"
       }
     },
     "right-align": {
@@ -4903,7 +4903,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -4911,7 +4911,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha512-5QIcndZ8am2WyseL6lln/utl51SwRBQs/at+zi1UnhsnPyZcAID+g0PZrKdb+kJn2fo/CwgyJweR8sP36Jer5g==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "ripemd160": {
@@ -4919,8 +4919,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
       "requires": {
-        "hash-base": "^2.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
       }
     },
     "safe-buffer": {
@@ -4957,18 +4957,18 @@
       "integrity": "sha512-EwaLqFmlXRHiqBkYXIuQ8WtslF3EwRslJwhdrhRv4ypTNpR1cGQlHLeH1SqMWwPdqf0CntKCV22+EWpFmW+QcQ==",
       "requires": {
         "debug": "2.6.8",
-        "depd": "~1.1.1",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.0",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
         "fresh": "0.5.0",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.2",
         "mime": "1.3.4",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.3.1"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
       },
       "dependencies": {
         "mime": {
@@ -4983,13 +4983,13 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
       "integrity": "sha512-btXPFKITJiodQ9CaH6RrvVFMNAT8TcYz5DHpXdtY/7rpG5EXUV5Bw8Pu8GVUzCHlkEXOhEOLntXLzMhirMsBXw==",
       "requires": {
-        "accepts": "~1.3.3",
+        "accepts": "1.3.3",
         "batch": "0.6.1",
         "debug": "2.6.8",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.1",
-        "mime-types": "~2.1.15",
-        "parseurl": "~1.3.1"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.2",
+        "mime-types": "2.1.16",
+        "parseurl": "1.3.1"
       }
     },
     "serve-static": {
@@ -4997,9 +4997,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
       "integrity": "sha512-S0jS3FQXrBdeOwbysweEhiB5ogGfVZND6H2c2Vh2RbriSPe8Bogtbb4J5ZUeViXS0v0YZYe7llGYrEXjK8fnqw==",
       "requires": {
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.1",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.1",
         "send": "0.15.4"
       }
     },
@@ -5013,7 +5013,7 @@
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha512-lIj6AWViymAQLQyq1qehP44w4iGbSv6pYOKRQCDzqlmxctLyCrecuge0bxRPrNSnV8EeMHKR2fVTRl3LniQLNg==",
       "requires": {
-        "to-object-path": "^0.3.0"
+        "to-object-path": "0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -5026,10 +5026,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
       "integrity": "sha512-2Z0LRUUvYeF7gIFFep48ksPq0NR09e5oKoFXznaMGNcu+EZAfGnyL0K6xno2gCqX6dZYEZRjrcn04/gvZzcKhQ==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.1",
-        "to-object-path": "^0.3.0"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "to-object-path": "0.3.0"
       }
     },
     "setimmediate": {
@@ -5047,7 +5047,7 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha512-O88cSHqkNUtD50hl7MXqkAlPbw1DcRBgiLRjHk3DtpGF0I6jlNN6yxCg1fIQX/Rl2PyrNK6LNuHG3FfBi0t3hQ==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "signal-exit": {
@@ -5060,15 +5060,15 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.2.0.tgz",
       "integrity": "sha512-Jg2Bcp+X5L0d5bMQqQzMPMh/oZ/TwwcgbVG5Z4xRPxKYqWYw75O6m4LrEhrQdOE10RsoaEQMwTFNn4rHjTyKew==",
       "requires": {
-        "diff": "^3.1.0",
+        "diff": "3.3.0",
         "formatio": "1.2.0",
-        "lolex": "^2.1.2",
-        "native-promise-only": "^0.8.1",
-        "nise": "^1.0.1",
-        "path-to-regexp": "^1.7.0",
-        "samsam": "^1.1.3",
+        "lolex": "2.1.2",
+        "native-promise-only": "0.8.1",
+        "nise": "1.0.1",
+        "path-to-regexp": "1.7.0",
+        "samsam": "1.2.1",
         "text-encoding": "0.6.4",
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.3"
       }
     },
     "snapdragon": {
@@ -5076,14 +5076,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
       "integrity": "sha512-fdVXpAHhS009K1+ldH0ZNPLgRK8TNw6KyOMohBhzufiYrVI2v/zIhQ16/W9mdKB7vrAJhYCtvmdSjnZGbG7/Zg==",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^2.0.0"
+        "base": "0.11.1",
+        "debug": "2.6.8",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.6",
+        "source-map-resolve": "0.5.0",
+        "use": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -5091,7 +5091,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -5099,9 +5099,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           }
         },
         "kind-of": {
@@ -5116,9 +5116,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       }
     },
     "snapdragon-util": {
@@ -5126,7 +5126,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5134,7 +5134,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -5271,8 +5271,8 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
       "integrity": "sha512-TYOxY9QjCiFd+9/Yj0QPMbl2xoO7wSggt0QQDff/5kcXf5ROXZo2tEsjHtRI0biEUJ2viLxI9JjCyTyr8q6h0A==",
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^2.0.2"
+        "faye-websocket": "0.10.0",
+        "uuid": "2.0.3"
       },
       "dependencies": {
         "uuid": {
@@ -5287,12 +5287,12 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
       "integrity": "sha512-hkDiI0wOmGmoUG3TSIrbDt8AhyzhePuNT3nogc5+c0amyUHu091y+jRK2h/e36olKRG+tSbhlQYHWqdsuW0CtQ==",
       "requires": {
-        "debug": "^2.6.6",
+        "debug": "2.6.8",
         "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.1.9"
       },
       "dependencies": {
         "faye-websocket": {
@@ -5300,7 +5300,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
           "integrity": "sha512-UfAKYOloAKPtWgu0YZtyRR0y1XQmZq2vZ0piJVMnJLfDctlqx2oIX4qoZDsiP7phmVpZ7gpqIwh1k2vfbbZBsg==",
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.6.5"
           }
         }
       }
@@ -5320,9 +5320,9 @@
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.1.tgz",
       "integrity": "sha512-/RHZ7v8sQl7iw7prf6rSoH+6XfZ8P/hFCGza89qUYCUvzLDSsMCsFharB5FewU6qLM8+wYDOipxBYxqYYPak1A==",
       "requires": {
-        "async": "^0.9.0",
-        "loader-utils": "~0.2.2",
-        "source-map": "~0.1.33"
+        "async": "0.9.2",
+        "loader-utils": "0.2.17",
+        "source-map": "0.1.43"
       },
       "dependencies": {
         "loader-utils": {
@@ -5330,10 +5330,10 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
           }
         },
         "source-map": {
@@ -5341,7 +5341,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -5351,10 +5351,10 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.0.tgz",
       "integrity": "sha512-3HnSRlPHZMKs84V7TnCyhhTVJAWoghTh4lbLZbv1OMOt4X0hLx5c2zQF3qsWD11v2QK0OB4RKMYZnbaHsBJPeg==",
       "requires": {
-        "atob": "^2.0.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.0.3",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -5362,7 +5362,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha512-oRP/tYo0d1l3D4f/bRWkWeLg80AxAqE225Vf1tbkuHZxANSgSQwfDHzDuhpS7U0ocKfwggp4PSAnMoRKsAgIZg==",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.6"
       }
     },
     "source-map-url": {
@@ -5383,7 +5383,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha512-A6UuuDdsSvKK2bqmUetv33zJVv0iczyaQZ536YL9+GAvbC4HceGKvXDtptnU9YZ/zGgryaFFsR4YaUCq+N/53g==",
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -5401,12 +5401,12 @@
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha512-jEvgkLRpMza5GON0oDzvLTLMAVfB5BxeOPbsWyisEyE8IbxL6cCiKbr8xrJdScs6XoOUp7pQy4PI+GVczHbO4w==",
       "requires": {
-        "debug": "^2.6.8",
-        "handle-thing": "^1.2.5",
-        "http-deceiver": "^1.2.7",
-        "safe-buffer": "^5.0.1",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^2.0.18"
+        "debug": "2.6.8",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.0.20"
       }
     },
     "spdy-transport": {
@@ -5414,13 +5414,13 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
       "integrity": "sha512-PMY2WVCit+Pf4FemVxnGSswrypCw8WdDu8XE1MsrkvnCC9K3IVed2Y2Y97s9q/MPVflzZzV47xF6TsQGalQhFA==",
       "requires": {
-        "debug": "^2.6.8",
-        "detect-node": "^2.0.3",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.1",
-        "readable-stream": "^2.2.9",
-        "safe-buffer": "^5.0.1",
-        "wbuf": "^1.7.2"
+        "debug": "2.6.8",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "wbuf": "1.7.2"
       }
     },
     "split": {
@@ -5428,7 +5428,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split-string": {
@@ -5436,7 +5436,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-2.1.1.tgz",
       "integrity": "sha512-BKUow/Ss4rA3BXWIvXzS1svK5f5SBGfKyigON1QNWepRFn4P68I9r1iAX+ZSYr6bDxJY4ds+PnBJ3PhdrhQJ6Q==",
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       }
     },
     "stackframe": {
@@ -5449,8 +5449,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -5458,7 +5458,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -5466,9 +5466,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           }
         },
         "kind-of": {
@@ -5488,8 +5488,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha512-nmQnY9D9TlnfQIkYJCCWxvCcQODilFRZIw14gCMYQVXOiY4E1Ze1VMxB+6y3qdXHpTordULo2qWloHmNcNAQYw==",
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       }
     },
     "stream-http": {
@@ -5497,11 +5497,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.2.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "string-width": {
@@ -5509,9 +5509,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string.prototype.trim": {
@@ -5519,9 +5519,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha512-IlEfUereZQqIcv/LJFNPUygFkq0HJCQMnaDr5i+zyRXpeYvF4F8J8u4UFxXICLMY+O3SEfJeaye5AO5miS6a9g==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.0",
+        "function-bind": "1.1.0"
       }
     },
     "string_decoder": {
@@ -5529,7 +5529,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -5537,7 +5537,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -5545,7 +5545,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-indent": {
@@ -5553,7 +5553,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha512-I5iQq6aFMM62fBEAIB/hXzwJD6EEZ0xEGCX2t7oXqaKPIRgt4WruAQ285BISgdkP+HLGWyeGmNJcpIwFeRYRUA==",
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "supports-color": {
@@ -5571,9 +5571,9 @@
       "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-1.4.2.tgz",
       "integrity": "sha512-66lGHiYP7ZJKnAuY0FQTi2e5N+IT7m+q1CMbyAb+XqbfdF+ZuDJEwu8NP3PKErKyrq9pVL+r/EflB+N5IanBog==",
       "requires": {
-        "re-emitter": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "split": "^1.0.0",
+        "re-emitter": "1.1.3",
+        "readable-stream": "2.3.3",
+        "split": "1.0.1",
         "trim": "0.0.1"
       }
     },
@@ -5582,14 +5582,14 @@
       "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-4.1.1.tgz",
       "integrity": "sha512-rGzWMZKz4S3FYN0X72V908NYH8eY8oJ2fADQByy8BcqJkJl3xnaiwym+2GjsPHLoHQ2n4yx+X5sIjAT0gWafHQ==",
       "requires": {
-        "chalk": "^1.0.0",
-        "duplexer": "^0.1.1",
-        "figures": "^1.4.0",
-        "lodash": "^3.6.0",
-        "pretty-ms": "^2.1.0",
-        "repeat-string": "^1.5.2",
-        "tap-out": "^1.4.1",
-        "through2": "^2.0.0"
+        "chalk": "1.1.3",
+        "duplexer": "0.1.1",
+        "figures": "1.7.0",
+        "lodash": "3.10.1",
+        "pretty-ms": "2.1.0",
+        "repeat-string": "1.6.1",
+        "tap-out": "1.4.2",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "lodash": {
@@ -5609,19 +5609,19 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "requires": {
-        "deep-equal": "~1.0.1",
-        "defined": "~1.0.0",
-        "for-each": "~0.3.2",
-        "function-bind": "~1.1.0",
-        "glob": "~7.1.2",
-        "has": "~1.0.1",
-        "inherits": "~2.0.3",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.3.0",
-        "resolve": "~1.4.0",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
-        "through": "~2.3.8"
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.0",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
       },
       "dependencies": {
         "minimist": {
@@ -5632,9 +5632,9 @@
       }
     },
     "tether": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.0.tgz",
-      "integrity": "sha512-Lho4NW+xIJBtXbSs50t2AnZDTc4MYsSXHl/QRhzJDP3t0hjL0f/UYHCDgRdPS+ZlwKwJ2FXB/vr/hJTpfM0hDA=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.5.tgz",
+      "integrity": "sha512-fysT1Gug2wbRi7a6waeu39yVDwiNtvwj5m9eRD+qZDSHKNghLo6KqP/U3yM2ap6TNUL2skjXGJaJJTJqoC31vw=="
     },
     "text-encoding": {
       "version": "0.6.4",
@@ -5651,8 +5651,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha512-tmNYYHFqXmaKSSlOU4ZbQ82cxmFQa5LRWKFtWCNkGIiZ3/VHmOffCeWfBRZZRyXAhNP9itVMR+cuvomBOPlm8g==",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       }
     },
     "thunky": {
@@ -5670,8 +5670,8 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.3.tgz",
       "integrity": "sha512-+JAqyNgg+M8+gXIrq2EeUr4kZqRz47Ysco7X5QKRGScRE9HIHckyHD1asozSFGeqx2nmPCgA8T5tIGVO0ML7/w==",
       "requires": {
-        "global": "^4.3.2",
-        "setimmediate": "^1.0.4"
+        "global": "4.3.2",
+        "setimmediate": "1.0.5"
       }
     },
     "tmp": {
@@ -5679,7 +5679,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha512-lfyEfOppKvWNeId5CArFLwgwef+iCnbEIy0JWYf1httIEXnx4ndL4Dr1adw7hPgeQfSlTbc/gqn6iaKcROpw5Q==",
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-array": {
@@ -5702,7 +5702,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5710,7 +5710,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -5720,9 +5720,9 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
       "integrity": "sha512-lSIz7PKxfLbP/dbEiTKL9Ove+h5AZ1VwI4TB3rF619tU4mFPvtA8tDuf3skAuKYtvZ3+zTqENZs07xyynLHswg==",
       "requires": {
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "regex-not": "^1.0.0"
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "regex-not": "1.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -5730,7 +5730,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -5738,9 +5738,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           }
         },
         "kind-of": {
@@ -5755,8 +5755,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "trim": {
@@ -5779,17 +5779,17 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
       "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.1.0",
-        "commander": "^2.9.0",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.7.1",
-        "tsutils": "^2.12.1"
+        "babel-code-frame": "6.22.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
+        "diff": "3.3.0",
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "resolve": "1.4.0",
+        "semver": "5.4.1",
+        "tslib": "1.7.1",
+        "tsutils": "2.12.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5797,7 +5797,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.0"
           }
         },
         "chalk": {
@@ -5805,9 +5805,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
@@ -5825,7 +5825,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -5835,7 +5835,7 @@
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz",
       "integrity": "sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=",
       "requires": {
-        "tslib": "^1.7.1"
+        "tslib": "1.7.1"
       }
     },
     "tty-browserify": {
@@ -5854,7 +5854,7 @@
       "integrity": "sha512-0uqZYZDiBICTVXEsNcDLueZLPgZ8FgGe8lmVDQ0FcVFUeaxsPbFWiz60ZChVw8VELIt7iGuCehOrZSYjYteWKQ==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
+        "mime-types": "2.1.16"
       }
     },
     "typescript": {
@@ -5872,9 +5872,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "yargs": {
@@ -5882,9 +5882,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -5906,10 +5906,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
       "integrity": "sha512-Tv3cqdyY8yjW9ZcJ9WP7JdHS34natzylD0oNRLlYbWOfUdC4EQ0sf3fubnqrK2IErtlmobFmuS1pWvv88VghpA==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       }
     },
     "unpipe": {
@@ -5922,8 +5922,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
       "integrity": "sha512-yhv5I4TsldLdE3UcVQn0hD2T5sNCPv4+qm/CTUpRKIpwthYRIipsAPdsrNpOI79hPQa0rTTeW22Fq6JWRcTgNg==",
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       }
     },
     "urix": {
@@ -5952,8 +5952,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
       "integrity": "sha512-gBwhoU2/umBG1wPK3MgGwLlaifJxzISumU7imrW9OV2hU7MMkmSfGQdN8AFnhBm1P/zamF7xt58Xq35/+pPrEg==",
       "requires": {
-        "querystringify": "~1.0.0",
-        "requires-port": "1.0.x"
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
       },
       "dependencies": {
         "querystringify": {
@@ -5968,9 +5968,9 @@
       "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
       "integrity": "sha512-RrhWfFWkNCz3djfSFZh7uSwu491QRhwNaHyAgB2sGl4kmmznb5ZUuuHpiWLVEsXOdpDakYK/x5+9o4lgg41UMw==",
       "requires": {
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.2"
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -5978,7 +5978,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-descriptor": {
@@ -5986,9 +5986,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.0.2"
           }
         },
         "kind-of": {
@@ -6003,8 +6003,8 @@
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
       "integrity": "sha512-VfMTzrCvxNEd/lcWvSXKYcCJNOL+d0lJEL7TWJ1GsQWspx858E/qUJucW05k+/C1evJ5AjIEvTodibhNA4Dqsw==",
       "requires": {
-        "lru-cache": "2.2.x",
-        "tmp": "0.0.x"
+        "lru-cache": "2.2.4",
+        "tmp": "0.0.31"
       }
     },
     "util": {
@@ -6042,8 +6042,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha512-VD0zBfAttoSxzPa+I+rF6ckOEEPSbifYNTSgRW5BsyfaD7gSE/uge00r2Xqa0d/yhF1MyHnMPHqLUdQRNimR2A==",
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "value-equal": {
@@ -6074,7 +6074,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "watchpack": {
@@ -6082,9 +6082,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
       "integrity": "sha512-83w+lJfZR76EQyEwYvKidiBXiK5Wb44JX0ecqLEsiB2Q4IqlCoct3HedvrGoEidQ/MoqbLecEMa40nFmDvQ4AA==",
       "requires": {
-        "async": "^2.1.2",
-        "chokidar": "^1.7.0",
-        "graceful-fs": "^4.1.2"
+        "async": "2.5.0",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "async": {
@@ -6092,7 +6092,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.4"
           }
         }
       }
@@ -6102,7 +6102,7 @@
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
       "integrity": "sha512-HuWNIFX5Rhr8sSpBVKjv6Hxw9CrDaNHTC9bWzCsOOFavJ1RwTZNAGmkLZKfhhi9w0o4VaTxHJnp2tgUnM4BsQg==",
       "requires": {
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "1.0.0"
       }
     },
     "webpack": {
@@ -6110,27 +6110,27 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
       "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
       "requires": {
-        "acorn": "^5.0.0",
-        "acorn-dynamic-import": "^2.0.0",
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.1.1",
-        "async": "^2.1.2",
-        "enhanced-resolve": "^3.3.0",
-        "interpret": "^1.0.0",
-        "json-loader": "^0.5.4",
-        "json5": "^0.5.1",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^0.2.16",
-        "memory-fs": "~0.4.1",
-        "mkdirp": "~0.5.0",
-        "node-libs-browser": "^2.0.0",
-        "source-map": "^0.5.3",
-        "supports-color": "^3.1.0",
-        "tapable": "~0.2.5",
-        "uglify-js": "^2.8.27",
-        "watchpack": "^1.3.1",
-        "webpack-sources": "^1.0.1",
-        "yargs": "^6.0.0"
+        "acorn": "5.1.1",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "async": "2.5.0",
+        "enhanced-resolve": "3.3.0",
+        "interpret": "1.0.3",
+        "json-loader": "0.5.7",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.0.0",
+        "source-map": "0.5.6",
+        "supports-color": "3.2.3",
+        "tapable": "0.2.8",
+        "uglify-js": "2.8.29",
+        "watchpack": "1.4.0",
+        "webpack-sources": "1.0.1",
+        "yargs": "6.6.0"
       },
       "dependencies": {
         "async": {
@@ -6138,7 +6138,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.4"
           }
         },
         "loader-utils": {
@@ -6146,10 +6146,10 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
           }
         },
         "supports-color": {
@@ -6157,7 +6157,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -6167,11 +6167,11 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
       "integrity": "sha512-wRSVvEfQf9hJf73gV6+zrUr+f/QRYN9fBw8LI8xptBXK5LdwmPo1q8lQef77bLA09Pvh9PJjT+1jXMEHBOhu1Q==",
       "requires": {
-        "memory-fs": "~0.4.1",
-        "mime": "^1.3.4",
-        "path-is-absolute": "^1.0.0",
-        "range-parser": "^1.0.3",
-        "time-stamp": "^2.0.0"
+        "memory-fs": "0.4.1",
+        "mime": "1.3.6",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0",
+        "time-stamp": "2.0.0"
       }
     },
     "webpack-dev-server": {
@@ -6180,28 +6180,28 @@
       "integrity": "sha512-6qvdjntkrpVTOAFxUznENTmMWT7+B+NzR2frvfdn/ePVv41YFdqyEfvsjbyT9OH5Eu7K/XujPACrHKEFgUBRqg==",
       "requires": {
         "ansi-html": "0.0.7",
-        "bonjour": "^3.5.0",
-        "chokidar": "^1.6.0",
-        "compression": "^1.5.2",
-        "connect-history-api-fallback": "^1.3.0",
-        "del": "^3.0.0",
-        "express": "^4.13.3",
-        "html-entities": "^1.2.0",
-        "http-proxy-middleware": "~0.17.4",
-        "internal-ip": "^1.2.0",
-        "ip": "^1.1.5",
-        "loglevel": "^1.4.1",
+        "bonjour": "3.5.0",
+        "chokidar": "1.7.0",
+        "compression": "1.7.0",
+        "connect-history-api-fallback": "1.3.0",
+        "del": "3.0.0",
+        "express": "4.15.4",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.17.4",
+        "internal-ip": "1.2.0",
+        "ip": "1.1.5",
+        "loglevel": "1.4.1",
         "opn": "4.0.2",
-        "portfinder": "^1.0.9",
-        "selfsigned": "^1.9.1",
-        "serve-index": "^1.7.2",
+        "portfinder": "1.0.13",
+        "selfsigned": "1.10.1",
+        "serve-index": "1.9.0",
         "sockjs": "0.3.18",
         "sockjs-client": "1.1.4",
-        "spdy": "^3.4.1",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^3.1.1",
-        "webpack-dev-middleware": "^1.11.0",
-        "yargs": "^6.0.0"
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "3.2.3",
+        "webpack-dev-middleware": "1.12.0",
+        "yargs": "6.6.0"
       },
       "dependencies": {
         "supports-color": {
@@ -6209,7 +6209,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -6219,8 +6219,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
       "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
       "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.5.3"
+        "source-list-map": "2.0.0",
+        "source-map": "0.5.6"
       }
     },
     "websocket-driver": {
@@ -6228,7 +6228,7 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha512-oBx6ZM1Gs5q2jwZuSN/Qxyy/fbgomV8+vqsmipaPKB/74hjHlKuM07jNmRhn4qa2AdUwsgxrltq+gaPsHgcl0Q==",
       "requires": {
-        "websocket-extensions": ">=0.1.1"
+        "websocket-extensions": "0.1.1"
       }
     },
     "websocket-extensions": {
@@ -6246,7 +6246,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -6269,8 +6269,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -6283,8 +6283,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
       "integrity": "sha512-lobrh3Dhp6tD1hv7NAIMx+oX/rsH/yd6/4krpBmJ/6ulsMZgQMuttlWTuYVWLV6ZjlpWIOjz55KbQbcKSQywEQ==",
       "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "wtf-8": {
@@ -6312,19 +6312,19 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha512-6/QWTdisjnu5UHUzQGst+UOEuEVwIzFVGBjq3jMTFNs5WJQsH/X6nMURSaScIdF5txylr1Ao9bvbWiKi2yXbwA==",
       "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^4.2.0"
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
       },
       "dependencies": {
         "camelcase": {
@@ -6337,9 +6337,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         }
       }
@@ -6349,7 +6349,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha512-+QQWqC2xeL0N5/TE+TY6OGEqyNRM+g2/r712PDNYgiCdXYCApXf1vzfmDSLBxfGRwV+moTq/V8FnMI24JCm2Yg==",
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "3.0.0"
       },
       "dependencies": {
         "camelcase": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "author": "Free & Fair",
     "license": "UNLICENSED",
     "dependencies": {
-        "@blueprintjs/core": "^1.23.0",
+        "@blueprintjs/core": "^1.39.0",
         "@blueprintjs/datetime": "^1.19.0",
         "@blueprintjs/labs": "^0.5.0",
         "@types/enzyme": "^2.8.1",

--- a/client/screen.css
+++ b/client/screen.css
@@ -57,13 +57,6 @@ div{
     margin-top: 10px;
 }
 
-.truncate {
-  width: 500px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .pt-breadcrumb {
     margin: 10px;
 }
@@ -76,31 +69,6 @@ div{
     border-spacing: 0;
     font-size: 16px !important;
 }
-
-.pt-file-upload-input::after {
-    background-color: #137cbd;
-    background-image: none;
-	color: #ffffff;
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: 100%;
-    margin-left: -1px;
-    border-radius: 3px;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    width: 70px;
-    height: 30px;
-    padding: 0 10px;
-    text-align: center;
-    line-height: 30px;
-    content: "Browse"; }
-
-
-  .pt-file-upload-input:hover::after {
-    box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 -1px 0 rgba(16, 22, 26, 0.1);
-    background-clip: padding-box;
-    background-color: #137cbd; }
 
 h2 {
     padding: 10px;

--- a/client/src/action/county/ballotNotFound.ts
+++ b/client/src/action/county/ballotNotFound.ts
@@ -3,15 +3,36 @@ import { endpoint } from 'corla/config';
 import createSubmitAction from 'corla/action/createSubmitAction';
 
 
+interface Payload {
+    comment?: string;
+    id: number;
+    reaudit?: boolean;
+}
+
 const url = endpoint('ballot-not-found');
 
-const ballotNotFound = createSubmitAction({
-    failType: 'BALLOT_NOT_FOUND_FAIL',
-    networkFailType: 'BALLOT_NOT_FOUND_NETWORK_FAIL',
-    okType: 'BALLOT_NOT_FOUND_OK',
-    sendType: 'BALLOT_NOT_FOUND_SEND',
-    url,
-});
+const ballotNotFound = (
+    id: number,
+    reAudit = false,
+    comment = '',
+) => {
+    const action = createSubmitAction({
+        failType: 'BALLOT_NOT_FOUND_FAIL',
+        networkFailType: 'BALLOT_NOT_FOUND_NETWORK_FAIL',
+        okType: 'BALLOT_NOT_FOUND_OK',
+        sendType: 'BALLOT_NOT_FOUND_SEND',
+        url,
+    });
+
+    const payload: Payload = { id };
+
+    if (reAudit) {
+        payload.comment = comment;
+        payload.reaudit = reAudit;
+    }
+
+    action(payload);
+};
 
 
-export default (id: number) => ballotNotFound({ id });
+export default ballotNotFound;

--- a/client/src/action/county/reAuditCvr.ts
+++ b/client/src/action/county/reAuditCvr.ts
@@ -1,0 +1,9 @@
+export default (state: County.AppState, action: Action.App) => {
+    const nextState = { ...state };
+    const { comment, cvrId } = action.data;
+
+    nextState.finalReview.comment = comment;
+    nextState.finalReview.ballotId = cvrId;
+
+    return nextState;
+};

--- a/client/src/action/county/uploadAcvr.ts
+++ b/client/src/action/county/uploadAcvr.ts
@@ -7,13 +7,24 @@ import { format } from 'corla/adapter/uploadAcvr';
 
 const url = endpoint('upload-audit-cvr');
 
-const uploadAcvr = createSubmitAction({
-    failType: 'UPLOAD_ACVR_FAIL',
-    networkFailType: 'UPLOAD_ACVR_NETWORK_FAIL',
-    okType: 'UPLOAD_ACVR_OK',
-    sendType: 'UPLOAD_ACVR_SEND',
-    url,
-});
+const uploadAcvr = (
+    acvr: County.ACVR,
+    cvr: CVR,
+    reAudit = false,
+    comment = '',
+) => {
+    const body = format(acvr, cvr, reAudit, comment);
+
+    const action = createSubmitAction({
+        failType: 'UPLOAD_ACVR_FAIL',
+        networkFailType: 'UPLOAD_ACVR_NETWORK_FAIL',
+        okType: 'UPLOAD_ACVR_OK',
+        sendType: 'UPLOAD_ACVR_SEND',
+        url,
+    });
+
+    action(body);
+};
 
 
-export default (acvr: County.ACVR, cvr: CVR) => uploadAcvr(format(acvr, cvr));
+export default uploadAcvr;

--- a/client/src/adapter/uploadAcvr.ts
+++ b/client/src/adapter/uploadAcvr.ts
@@ -12,19 +12,33 @@ const formatContestInfo = (mark: County.ACVRContest, contestId: number): JSON.Co
 };
 
 
-export const format = (marks: County.ACVR, cvr: CVR): JSON.ACVR => ({
-    audit_cvr: {
-        ballot_type: cvr.ballotType,
-        batch_id: cvr.batchId,
-        contest_info: _.map(marks, formatContestInfo),
-        county_id: cvr.countyId,
-        cvr_number: cvr.cvrNumber,
-        id: cvr.id,
-        imprinted_id: cvr.imprintedId,
-        record_id: cvr.recordId,
-        record_type: cvr.recordType,
-        scanner_id: cvr.scannerId,
-        timestamp: new Date(),
-    },
-    cvr_id: cvr.id,
-});
+export const format = (
+    acvr: County.ACVR,
+    cvr: CVR,
+    reAudit: boolean,
+    comment: string,
+): JSON.ACVR => {
+    const payload: JSON.ACVR = {
+        audit_cvr: {
+            ballot_type: cvr.ballotType,
+            batch_id: cvr.batchId,
+            contest_info: _.map(acvr, formatContestInfo),
+            county_id: cvr.countyId,
+            cvr_number: cvr.cvrNumber,
+            id: cvr.id,
+            imprinted_id: cvr.imprintedId,
+            record_id: cvr.recordId,
+            record_type: cvr.recordType,
+            scanner_id: cvr.scannerId,
+            timestamp: new Date(),
+        },
+        cvr_id: cvr.id,
+    };
+
+    if (reAudit) {
+        payload.reaudit = true;
+        payload.comment = comment;
+    }
+
+    return payload;
+};

--- a/client/src/component/County/Audit/EndOfRound/FinalReviewDialog.tsx
+++ b/client/src/component/County/Audit/EndOfRound/FinalReviewDialog.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+
+import { Button, Dialog, FormGroup, Intent, TextArea } from '@blueprintjs/core';
+
+import action from 'corla/action/';
+
+
+interface FinalReviewDialogProps {
+    cvr?: JSON.CVR;
+    onClose: () => void;
+    isOpen: boolean;
+}
+
+interface FinalReviewDialogState {
+    comment: string;
+    hasError: boolean;
+}
+
+class FinalReviewDialog extends React.Component<FinalReviewDialogProps, FinalReviewDialogState> {
+    constructor(props: FinalReviewDialogProps) {
+        super(props);
+
+        this.state = { comment: '', hasError: true };
+    }
+
+    public render() {
+        const cvr = this.props.cvr;
+
+        const title = cvr ? 'Re-audit ' + cvr.imprinted_id : 'Re-audit';
+
+        return (
+            <Dialog iconName='confirm'
+                    isOpen={ this.props.isOpen }
+                    onClose={ this.handleCancel }
+                    title={ title }>
+                <div className='pt-dialog-body'>
+                    <p>
+                        To re-audit this ballot, please explain your reason for
+                        re-auditing this ballot in the space below and click
+                        "Next". To go back, click "Back".
+                    </p>
+                    <FormGroup intent={ this.formIntent() }
+                               label='Reason for re-audit '
+                               labelFor='review-dialog-input'
+                               requiredLabel={ true }>
+                        <TextArea id='review-dialog-input'
+                                  className='pt-fill'
+                                  intent={ this.formIntent() }
+                                  value={ this.state.comment }
+                                  onChange={ this.handleCommentChange } />
+                    </FormGroup>
+                </div>
+                <div className='pt-dialog-footer'>
+                    <div className='pt-dialog-footer-actions'>
+                        <Button text='Cancel'
+                                onClick={ this.handleCancel } />
+                        <Button intent={ Intent.PRIMARY }
+                                onClick={ this.handleReAudit }
+                                text='Next' />
+                    </div>
+                </div>
+            </Dialog>
+        );
+    }
+
+    private formIntent = (): Intent => {
+        return this.state.hasError ? Intent.DANGER : Intent.NONE;
+    }
+
+    private handleCancel = () => {
+        this.props.onClose();
+    }
+
+    private handleCommentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        this.setState({
+            comment: e.target.value,
+            hasError: e.target.value.length < 1,
+        });
+    }
+
+    private handleReAudit = () => {
+        if (this.state.hasError) {
+            return;
+        }
+
+        const cvr = this.props.cvr;
+
+        if (cvr) {
+            action('RE_AUDIT_CVR', {
+                comment: this.state.comment,
+                cvrId: cvr.db_id,
+            });
+        }
+    }
+}
+
+export default FinalReviewDialog;

--- a/client/src/component/County/Audit/EndOfRound/FinalReviewPage.tsx
+++ b/client/src/component/County/Audit/EndOfRound/FinalReviewPage.tsx
@@ -1,0 +1,170 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+
+import CountyNav from 'corla/component/County/Nav';
+
+import { auditBoardSlice } from 'corla/selector/county/currentBallotNumber';
+
+import FinalReviewDialog from './FinalReviewDialog';
+
+import { Button, IButtonProps } from '@blueprintjs/core';
+
+import action from 'corla/action/';
+
+interface ReviewButtonProps {
+    cvr: JSON.CVR;
+    open: (cvr: JSON.CVR) => void;
+}
+
+const ReviewButton = (props: ReviewButtonProps) => {
+    const handler: IButtonProps['onClick'] = () => {
+        if (props.cvr.db_id != null) {
+            props.open(props.cvr);
+        } else {
+            alert('Sorry, this ballot cannot be re-audited.');
+        }
+    };
+
+    return (
+        <Button text='Re-audit'
+                onClick={ handler }  />
+    );
+};
+
+interface FinalReviewPageProps {
+    auditBoardIndex: number;
+    ballotSequenceAssignment?: object[];
+    cvrsToAudit?: JSON.CVR[];
+}
+
+interface FinalReviewPageState {
+    dialogIsOpen: boolean;
+    cvr?: JSON.CVR;
+}
+
+const reviewCompleteHandler = (auditBoardIndex: number) => {
+    return () => {
+        action('FINAL_REVIEW_COMPLETE', auditBoardIndex);
+    };
+};
+
+const rowRenderer = (open: (cvr: JSON.CVR) => void) => {
+    return (cvr: JSON.CVR) => {
+        return (
+            <tr key={ cvr.db_id }>
+                <td>{ cvr.storage_location }</td>
+                <td>{ cvr.scanner_id }</td>
+                <td>{ cvr.batch_id }</td>
+                <td>{ cvr.record_id }</td>
+                <td>{ cvr.ballot_type }</td>
+                <td><ReviewButton cvr={ cvr }
+                                  open={ open } /></td>
+            </tr>
+        );
+    };
+};
+
+class FinalReviewPage extends React.Component<FinalReviewPageProps, FinalReviewPageState> {
+    constructor(props: FinalReviewPageProps) {
+        super(props);
+        this.state = { dialogIsOpen: false, cvr: undefined };
+    }
+
+    public render() {
+        const {
+            auditBoardIndex,
+            ballotSequenceAssignment,
+            cvrsToAudit,
+        } = this.props;
+
+        const renderRow = rowRenderer(this.openDialog);
+
+        return (
+            <div>
+                <CountyNav />
+                <div className='pt-card'>
+                    <FinalReviewDialog cvr={ this.state.cvr }
+                                       isOpen={ this.state.dialogIsOpen }
+                                       onClose={ this.closeDialog } />
+
+                    <h3>Audit Board { auditBoardIndex + 1 }: Final Review</h3>
+
+                    <div className='pt-card'>
+                        <p>
+                            This screen allows you to re-audit ballots previously audited in
+                            this round. If you choose to re-audit a ballot, you will be
+                            presented with blank data entry and review screens for that ballot -
+                            data from the previous audit will not be prefilled. Once you submit
+                            a re-audited ballot, the most recent data will replace older
+                            entries. You will be able to re-audit multiple ballots if you wish.
+                        </p>
+
+                        <p>
+                            <b>
+                                If you are satisfied with your initial data entry and
+                                wish to complete the round:
+                            </b>
+                        </p>
+
+                        <ul>
+                            <li><b>Click the button below labeled "Review Complete - Finish Round"</b></li>
+                        </ul>
+
+                        <p>
+                            <b>
+                                If you wish to re-audit a ballot:
+                            </b>
+                        </p>
+
+                        <ul>
+                            <li><b>Click the "re-audit" button next to the appropriate ballot card in the list below</b></li>
+                        </ul>
+
+                        <p>
+                            When you are finished, click "Review Complete - Finish Round." Once clicked, ballot data from
+                            this round of the audit is no longer editable.
+                        </p>
+
+                        <Button onClick={ reviewCompleteHandler(auditBoardIndex) }>
+                            Review Complete - Finish Round
+                        </Button>
+                    </div>
+
+                    <table className='pt-table pt-bordered pt-condensed pt-interactive'
+                           style={{ marginLeft: 'auto', marginRight: 'auto' }}>
+                        <thead>
+                            <tr>
+                                <th>Storage bin</th>
+                                <th>Scanner</th>
+                                <th>Batch</th>
+                                <th>Ballot position</th>
+                                <th>Ballot type</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {
+                            _.map(auditBoardSlice(
+                                cvrsToAudit,
+                                ballotSequenceAssignment,
+                                auditBoardIndex,
+                            ), renderRow)
+                        }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        );
+    }
+
+    private closeDialog: () => void = () => {
+        this.setState({ dialogIsOpen: false, cvr: undefined });
+    }
+
+    private openDialog: (cvr: JSON.CVR) => void = cvr => {
+        this.setState({ dialogIsOpen: true, cvr });
+    }
+}
+
+
+export default FinalReviewPage;

--- a/client/src/component/County/Audit/EndOfRound/FinalReviewPageContainer.tsx
+++ b/client/src/component/County/Audit/EndOfRound/FinalReviewPageContainer.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import FinalReviewPage from './FinalReviewPage';
+
+import allRoundsCompleteSelector from 'corla/selector/county/allRoundsComplete';
+import countyInfoSelector from 'corla/selector/county/countyInfo';
+import currentRoundNumberSelector from 'corla/selector/county/currentRoundNumber';
+import previousRoundSelector from 'corla/selector/county/previousRound';
+
+
+interface Props {
+    auditBoardIndex: number;
+    ballotSequenceAssignment?: object[];
+    cvrsToAudit?: JSON.CVR[];
+}
+
+const Container = (props: Props) => {
+    return <FinalReviewPage { ...props } />;
+};
+
+const select = (state: County.AppState) => {
+    return {
+        auditBoardIndex: state.auditBoardIndex || 0,
+        ballotSequenceAssignment: state.ballotSequenceAssignment,
+        cvrsToAudit: state.cvrsToAudit,
+    };
+};
+
+
+export default connect(select)(Container);

--- a/client/src/component/County/Audit/EndOfRound/Page.tsx
+++ b/client/src/component/County/Audit/EndOfRound/Page.tsx
@@ -60,10 +60,10 @@ interface PageProps {
     auditBoardIndex: number;
     countyInfo: CountyInfo;
     currentRoundNumber: number;
+    cvrsToAudit: JSON.CVR[];
     election: Election;
     estimatedBallotsToAudit: number;
     previousRound: Round;
-    previousRoundSignedOff: boolean;
 }
 
 const EndOfRoundPage = (props: PageProps) => {
@@ -72,10 +72,10 @@ const EndOfRoundPage = (props: PageProps) => {
         auditBoardIndex,
         countyInfo,
         currentRoundNumber,
+        cvrsToAudit,
         election,
         estimatedBallotsToAudit,
         previousRound,
-        previousRoundSignedOff,
     } = props;
 
     const countyName = countyInfo.name;
@@ -83,13 +83,6 @@ const EndOfRoundPage = (props: PageProps) => {
 
     if (allRoundsComplete && estimatedBallotsToAudit <= 0) {
         return <LastRoundComplete />;
-    }
-
-    if (previousRoundSignedOff) {
-        notice.ok('Congratulations! You have finished auditing your board’s'
-            + ` ballots in round ${roundNumber}. Please wait for any other`
-            + ' audit boards to complete the audit.');
-        return <Redirect to='/county' />;
     }
 
     const electionDate = corlaDate.format(election.date);

--- a/client/src/component/County/Audit/EndOfRound/PageContainer.tsx
+++ b/client/src/component/County/Audit/EndOfRound/PageContainer.tsx
@@ -9,31 +9,15 @@ import currentRoundNumberSelector from 'corla/selector/county/currentRoundNumber
 import previousRoundSelector from 'corla/selector/county/previousRound';
 
 
-function signedOff(auditBoardIndex: number, round: Round): boolean {
-    if (!round.signatories) {
-        return false;
-    }
-
-    if (!round.signatories[auditBoardIndex]) {
-        return false;
-    }
-
-    if (round.signatories[auditBoardIndex].length < 2) {
-        return false;
-    }
-
-    return true;
-}
-
 interface ContainerProps {
     allRoundsComplete: boolean;
     auditBoardIndex: number;
     countyInfo: CountyInfo;
     currentRoundNumber: number;
+    cvrsToAudit: JSON.CVR[];
     election: Election;
     estimatedBallotsToAudit: number;
     previousRound: Round;
-    previousRoundSignedOff: boolean;
 }
 
 class EndOfRoundPageContainer extends React.Component<ContainerProps> {
@@ -43,22 +27,18 @@ class EndOfRoundPageContainer extends React.Component<ContainerProps> {
 }
 
 function select(countyState: County.AppState) {
-    // TODO: No great way to handle this error.
-    // Note that 0 is falsey in JS, so this still works for a valid audit board
-    // index of 0.
     const auditBoardIndex = countyState.auditBoardIndex || 0;
     const previousRound = previousRoundSelector(countyState);
-    const previousRoundSignedOff = previousRound && signedOff(auditBoardIndex, previousRound);
 
     return {
         allRoundsComplete: allRoundsCompleteSelector(countyState),
         auditBoardIndex,
         countyInfo: countyInfoSelector(countyState),
         currentRoundNumber: currentRoundNumberSelector(countyState),
+        cvrsToAudit: countyState.cvrsToAudit,
         election: countyState.election,
         estimatedBallotsToAudit: countyState.estimatedBallotsToAudit,
         previousRound: previousRound || {},
-        previousRoundSignedOff: previousRound ? signedOff(auditBoardIndex, previousRound) : false,
     };
 }
 

--- a/client/src/component/County/Audit/Page.tsx
+++ b/client/src/component/County/Audit/Page.tsx
@@ -4,12 +4,17 @@ import CountyNav from '../Nav';
 
 import CountyAuditWizardContainer from './Wizard/Container';
 
+interface Props {
+    reviewingBallotId?: number;
+}
 
-const CountyAuditPage = () => {
+const CountyAuditPage = (props: Props) => {
+    const { reviewingBallotId } = props;
+
     return (
         <div>
             <CountyNav />
-            <CountyAuditWizardContainer />
+            <CountyAuditWizardContainer reviewingBallotId={ reviewingBallotId } />
         </div>
     );
 };

--- a/client/src/component/County/Audit/PageContainer.tsx
+++ b/client/src/component/County/Audit/PageContainer.tsx
@@ -4,6 +4,7 @@ import { Redirect } from 'react-router-dom';
 import withCountyState from 'corla/component/withCountyState';
 import withPoll from 'corla/component/withPoll';
 
+import FinalReviewPageContainer from './EndOfRound/FinalReviewPageContainer';
 import EndOfRoundPageContainer from './EndOfRound/PageContainer';
 import CountyAuditPage from './Page';
 
@@ -13,59 +14,103 @@ import allRoundsCompleteSelector from 'corla/selector/county/allRoundsComplete';
 import auditCompleteSelector from 'corla/selector/county/auditComplete';
 import canAuditSelector from 'corla/selector/county/canAudit';
 import isAuditBoardDoneSelector from 'corla/selector/county/isAuditBoardDone';
+import previousRoundSelector from 'corla/selector/county/previousRound';
 import roundInProgressSelector from 'corla/selector/county/roundInProgress';
 
 
-interface ContainerProps {
-    auditBoardIndex: number;
+function signedOff(auditBoardIndex: number, round: Round): boolean {
+    if (!round.signatories) {
+        return false;
+    }
+
+    if (!round.signatories[auditBoardIndex]) {
+        return false;
+    }
+
+    if (round.signatories[auditBoardIndex].length < 2) {
+        return false;
+    }
+
+    return true;
+}
+
+interface CountyAuditPageContainerProps {
     auditComplete: boolean;
     canAudit: boolean;
-    isAuditBoardDone: boolean;
+    finalReviewComplete: boolean;
+    previousRoundSignedOff: boolean;
+    reviewingBallotId?: number;
+    roundNumber: number;
     showEndOfRoundPage: boolean;
 }
 
-class CountyAuditContainer extends React.Component<ContainerProps> {
-    public render() {
-        const { auditComplete,
-                canAudit,
-                showEndOfRoundPage } = this.props;
+const CountyAuditPageContainer = (props: CountyAuditPageContainerProps) => {
+    const {
+        auditComplete,
+        canAudit,
+        finalReviewComplete,
+        previousRoundSignedOff,
+        reviewingBallotId,
+        roundNumber,
+        showEndOfRoundPage,
+    } = props;
 
-        if (auditComplete) {
-            notice.ok('The audit is complete.');
-
-            return <Redirect to={ '/county' } />;
-        }
-
-        if (!canAudit) {
-            return <Redirect to={ '/county' } />;
-        }
-
-        if (showEndOfRoundPage) {
-            return <EndOfRoundPageContainer />;
-        }
-
-        return <CountyAuditPage />;
+    if (!canAudit) {
+        return <Redirect to='/county' />;
     }
-}
+
+    if (auditComplete) {
+        notice.ok('The audit is complete.');
+
+        return <Redirect to='/county' />;
+    }
+
+    if (previousRoundSignedOff) {
+        notice.ok('Congratulations! You have finished auditing your board’s'
+            + ` ballots in round ${roundNumber}. Please wait for any other`
+            + ' audit boards to complete the audit.');
+
+        return <Redirect to='/county' />;
+    }
+
+    if (showEndOfRoundPage && finalReviewComplete) {
+        return <EndOfRoundPageContainer />;
+    } else if (showEndOfRoundPage && !finalReviewComplete) {
+        return <FinalReviewPageContainer />;
+    }
+
+    return <CountyAuditPage reviewingBallotId={ reviewingBallotId } />;
+};
 
 function select(countyState: County.AppState) {
+    const auditBoardIndex = countyState.auditBoardIndex || 0;
     const isAuditBoardDone = isAuditBoardDoneSelector(countyState);
-    const showEndOfRoundPage = allRoundsCompleteSelector(countyState)
-        || !roundInProgressSelector(countyState)
-        || isAuditBoardDone;
+    const finalReviewComplete = countyState.finalReview.complete;
+    const previousRound = previousRoundSelector(countyState);
+    const reviewingBallotId = countyState.finalReview.ballotId;
+    const roundNumber = previousRound ? previousRound.number : 0;
+    const showEndOfRoundPage =
+        (allRoundsCompleteSelector(countyState)
+         || !roundInProgressSelector(countyState)
+         || isAuditBoardDone)
+        && reviewingBallotId == null;
+    const previousRoundSignedOff = previousRound
+        && signedOff(auditBoardIndex, previousRound);
 
     return {
-        auditBoardIndex: countyState.auditBoardIndex,
         auditComplete: auditCompleteSelector(countyState),
         canAudit: canAuditSelector(countyState),
-        isAuditBoardDone: isAuditBoardDoneSelector(countyState),
+        finalReviewComplete,
+        previousRoundSignedOff,
+        reviewingBallotId,
+        roundNumber,
         showEndOfRoundPage,
     };
 }
 
 
 export default withPoll(
-    withCountyState(CountyAuditContainer),
+    withCountyState(CountyAuditPageContainer),
     'COUNTY_AUDIT_POLL_START',
     'COUNTY_AUDIT_POLL_STOP',
     select,

--- a/client/src/component/County/Audit/Wizard/BallotAuditStage.tsx
+++ b/client/src/component/County/Audit/Wizard/BallotAuditStage.tsx
@@ -10,19 +10,18 @@ import WaitingForNextBallot from './WaitingForNextBallot';
 import CommentIcon from '../../../CommentIcon';
 
 import ballotNotFound from 'corla/action/county/ballotNotFound';
-import countyFetchCvr from 'corla/action/county/fetchCvr';
 
 
 interface NotFoundProps {
-    ballotNotFound: OnClick;
+    notFound: OnClick;
     currentBallot: CVR;
 }
 
 const BallotNotFoundForm = (props: NotFoundProps) => {
-    const { ballotNotFound, currentBallot } = props;
+    const { notFound, currentBallot } = props;
     const onClick = () => {
         if (confirm('By continuing, this ballot will be recorded as “not found” and you will move on to the next ballot.')) {
-            ballotNotFound(currentBallot.id);
+            notFound();
         }
     };
 
@@ -42,18 +41,14 @@ const BallotNotFoundForm = (props: NotFoundProps) => {
 };
 
 interface AuditInstructionsProps {
-    ballotNotFound: OnClick;
     countyState: County.AppState;
     currentBallot: CVR;
-    currentBallotNumber: number;
 }
 
 const AuditInstructions = (props: AuditInstructionsProps) => {
     const {
-        ballotNotFound,
         countyState,
         currentBallot,
-        currentBallotNumber,
     } = props;
 
     const isCurrentCvr = (cvr: JSON.CVR) => cvr.db_id === currentBallot.id;
@@ -262,30 +257,45 @@ const BallotAuditForm = (props: AuditFormProps) => {
 
 interface StageProps {
     auditBoardIndex: number;
+    comment?: string;
     countyState: County.AppState;
-    currentBallot: County.CurrentBallot;
-    currentBallotNumber: number;
+    currentBallot?: County.CurrentBallot;
+    currentBallotNumber?: number;
+    isReAuditing: boolean;
     nextStage: OnClick;
     prevStage: OnClick;
-    totalBallotsForBoard: number;
-    updateBallotMarks: OnClick;
+    totalBallotsForBoard?: number;
+    updateBallotMarks: (data: any) => any;
 }
-
 
 const BallotAuditStage = (props: StageProps) => {
     const {
         auditBoardIndex,
+        comment,
         countyState,
         currentBallot,
         currentBallotNumber,
+        isReAuditing,
         nextStage,
         prevStage,
         totalBallotsForBoard,
         updateBallotMarks,
     } = props;
 
+    if (currentBallot == null) {
+        return <WaitingForNextBallot />;
+    }
+
+    if (currentBallotNumber == null) {
+        return <WaitingForNextBallot />;
+    }
+
     const notFound = () => {
-        ballotNotFound(currentBallot.id);
+        if (isReAuditing) {
+            ballotNotFound(currentBallot.id, true, comment);
+        } else {
+            ballotNotFound(currentBallot.id);
+        }
     };
 
     const validateAcvr = () => {
@@ -331,14 +341,12 @@ const BallotAuditStage = (props: StageProps) => {
                 <div className='col-layout row1'>
                     <div className='col1'>
                         <AuditInstructions
-                            ballotNotFound={ notFound }
                             countyState={ countyState }
-                            currentBallot={ currentBallot }
-                            currentBallotNumber={ currentBallotNumber } />
+                            currentBallot={ currentBallot } />
                     </div>
                     <div className='col2'>
                         <BallotNotFoundForm
-                            ballotNotFound={ ballotNotFound }
+                            notFound={ notFound }
                             currentBallot={ currentBallot } />
                     </div>
                 </div>

--- a/client/src/component/County/Audit/Wizard/BallotAuditStageContainer.tsx
+++ b/client/src/component/County/Audit/Wizard/BallotAuditStageContainer.tsx
@@ -11,38 +11,42 @@ import currentBallotNumber from 'corla/selector/county/currentBallotNumber';
 import totalBallotsForBoard from 'corla/selector/county/totalBallotsForBoard';
 
 
-interface ContainerProps {
+interface StateProps {
     auditBoardIndex: number;
+    comment?: string;
+    currentBallot?: County.CurrentBallot;
+    isReAuditing: boolean;
+    updateBallotMarks: OnClick;
+}
+
+interface OwnProps {
     countyState: County.AppState;
-    currentBallot: County.CurrentBallot;
-    currentBallotNumber: number;
+    currentBallotNumber?: number;
+    reviewingBallotId?: number;
+    totalBallotsForBoard?: number;
     nextStage: OnClick;
     prevStage: OnClick;
-    totalBallotsForBoard: number;
 }
 
-class BallotAuditStageContainer extends React.Component<ContainerProps> {
-    public render() {
-        const props = {
-            ...this.props,
-            updateBallotMarks: (data: any) => action('UPDATE_ACVR_FORM', data),
-        };
+type Props = StateProps & OwnProps;
 
-        return <BallotAuditStage { ...props } />;
-    }
-}
+const Component = (props: Props) => <BallotAuditStage { ...props } />;
 
-function select(countyState: County.AppState) {
+const select = (countyState: County.AppState): StateProps => {
     const { currentBallot } = countyState;
 
+    const comment = countyState.finalReview.comment;
+
+    const updateBallotMarks = (data: any) =>
+        action('UPDATE_ACVR_FORM', data);
+
     return {
-        auditBoardIndex: countyState.auditBoardIndex,
-        countyState,
+        auditBoardIndex: countyState.auditBoardIndex || 0,
+        comment,
         currentBallot,
-        currentBallotNumber: currentBallotNumber(countyState),
-        totalBallotsForBoard: totalBallotsForBoard(countyState),
+        isReAuditing: !!comment,
+        updateBallotMarks,
     };
-}
+};
 
-
-export default connect(select)(BallotAuditStageContainer);
+export default connect(select)(Component);

--- a/client/src/component/County/Audit/Wizard/Container.tsx
+++ b/client/src/component/County/Audit/Wizard/Container.tsx
@@ -30,7 +30,7 @@ function select(countyState: County.AppState) {
     return {
       countyState,
       currentBallotNumber: currentBallotNumber(countyState),
-      totalBallotsForBoard: currentBallotNumber(countyState),
+      totalBallotsForBoard: totalBallotsForBoard(countyState),
     };
 }
 

--- a/client/src/component/County/Audit/Wizard/Container.tsx
+++ b/client/src/component/County/Audit/Wizard/Container.tsx
@@ -1,38 +1,36 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import CountyAuditWizard from './Wizard';
+import Wizard from './Wizard';
 
 import currentBallotNumber from 'corla/selector/county/currentBallotNumber';
 import totalBallotsForBoard from 'corla/selector/county/totalBallotsForBoard';
 
-
-interface WizardContainerProps {
+interface WizardContainerStateProps {
     countyState: County.AppState;
-    currentBallotNumber: number;
-    totalBallotsForBoard: number;
+    currentBallotNumber?: number;
+    totalBallotsForBoard?: number;
 }
 
-class CountyAuditWizardContainer extends React.Component<WizardContainerProps> {
-    public render() {
-        const {
-          currentBallotNumber,
-          totalBallotsForBoard,
-        } = this.props;
-
-        return <CountyAuditWizard currentBallotNumber={ currentBallotNumber }
-                                  totalBallotsForBoard={ totalBallotsForBoard }
-                                  { ...this.props } />;
-    }
+interface WizardContainerOwnProps {
+    reviewingBallotId?: number;
 }
 
-function select(countyState: County.AppState) {
+interface WizardContainerProps extends
+    WizardContainerStateProps, WizardContainerOwnProps {}
+
+const WizardContainer = (props: WizardContainerProps) => {
+    return <Wizard { ...props } />;
+};
+
+function select(state: County.AppState, props: WizardContainerOwnProps) {
     return {
-      countyState,
-      currentBallotNumber: currentBallotNumber(countyState),
-      totalBallotsForBoard: totalBallotsForBoard(countyState),
+        countyState: state,
+        currentBallotNumber: currentBallotNumber(state),
+        reviewingBallotId: props.reviewingBallotId,
+        totalBallotsForBoard: totalBallotsForBoard(state),
     };
 }
 
 
-export default connect(select)(CountyAuditWizardContainer);
+export default connect(select)(WizardContainer);

--- a/client/src/component/County/Audit/Wizard/ReviewStage.tsx
+++ b/client/src/component/County/Audit/Wizard/ReviewStage.tsx
@@ -154,21 +154,25 @@ const BallotReview = (props: BallotReviewProps) => {
 };
 
 interface ReviewStageProps {
+    comment?: string;
     countyState: County.AppState;
     currentBallot: County.CurrentBallot;
-    currentBallotNumber: number;
+    currentBallotNumber?: number;
+    isReAuditing?: boolean;
     marks: County.ACVR;
     nextStage: OnClick;
     prevStage: OnClick;
     uploadAcvr: OnClick;
-    totalBallotsForBoard: number;
+    totalBallotsForBoard?: number;
 }
 
 const ReviewStage = (props: ReviewStageProps) => {
     const {
+        comment,
         countyState,
         currentBallot,
         currentBallotNumber,
+        isReAuditing,
         marks,
         nextStage,
         prevStage,
@@ -180,7 +184,12 @@ const ReviewStage = (props: ReviewStageProps) => {
         const m = countyState!.acvrs![currentBallot.id];
 
         try {
-            await uploadAcvr(m, currentBallot);
+            if (isReAuditing) {
+                await uploadAcvr(m, currentBallot, true, comment);
+            } else {
+                await uploadAcvr(m, currentBallot);
+            }
+
             nextStage();
         } catch {
             // Failed to submit. Let saga machinery alert user.

--- a/client/src/component/County/Audit/Wizard/ReviewStageContainer.tsx
+++ b/client/src/component/County/Audit/Wizard/ReviewStageContainer.tsx
@@ -10,21 +10,25 @@ import totalBallotsForBoard from 'corla/selector/county/totalBallotsForBoard';
 
 
 interface ContainerProps {
+    comment?: string;
     countyState: County.AppState;
     currentBallot?: County.CurrentBallot;
-    currentBallotNumber: number;
+    currentBallotNumber?: number;
+    isReAuditing?: boolean;
     marks?: County.ACVR;
     nextStage: OnClick;
     prevStage: OnClick;
-    totalBallotsForBoard: number;
+    totalBallotsForBoard?: number;
 }
 
 class ReviewStageContainer extends React.Component<ContainerProps> {
     public render() {
         const {
+            comment,
             countyState,
             currentBallot,
             currentBallotNumber,
+            isReAuditing,
             marks,
             nextStage,
             prevStage,
@@ -39,9 +43,11 @@ class ReviewStageContainer extends React.Component<ContainerProps> {
             return null;
         }
 
-        return <ReviewStage countyState={ countyState }
+        return <ReviewStage comment={ comment }
+                            countyState={ countyState }
                             currentBallot={ currentBallot }
                             currentBallotNumber={ currentBallotNumber }
+                            isReAuditing={ isReAuditing }
                             marks={ marks }
                             nextStage={ nextStage }
                             prevStage={ prevStage }
@@ -53,6 +59,8 @@ class ReviewStageContainer extends React.Component<ContainerProps> {
 function select(countyState: County.AppState) {
     const { currentBallot } = countyState;
 
+    const comment = countyState.finalReview.comment;
+
     if (!currentBallot) {
         return { countyState };
     }
@@ -60,11 +68,13 @@ function select(countyState: County.AppState) {
     const marks = countyState.acvrs[currentBallot.id];
 
     return {
-      countyState,
-      currentBallot,
-      currentBallotNumber: currentBallotNumber(countyState),
-      marks,
-      totalBallotsForBoard: totalBallotsForBoard(countyState),
+        comment,
+        countyState,
+        currentBallot,
+        currentBallotNumber: currentBallotNumber(countyState),
+        isReAuditing: !!comment,
+        marks,
+        totalBallotsForBoard: totalBallotsForBoard(countyState),
     };
 }
 

--- a/client/src/component/County/Audit/Wizard/Wizard.tsx
+++ b/client/src/component/County/Audit/Wizard/Wizard.tsx
@@ -14,8 +14,9 @@ interface TransitionTable {
 
 interface WizardProps {
     countyState: County.AppState;
-    currentBallotNumber: number;
-    totalBallotsForBoard: number;
+    currentBallotNumber?: number;
+    reviewingBallotId?: number;
+    totalBallotsForBoard?: number;
 }
 
 interface WizardState {
@@ -26,16 +27,24 @@ class CountyAuditWizard extends React.Component<WizardProps, WizardState> {
     constructor(props: WizardProps) {
         super(props);
 
-        this.state = { stage: 'list' };
+        if (props.reviewingBallotId != null) {
+            this.state = { stage: 'ballot-audit' };
+
+            window.scrollTo(0, 0);
+        } else {
+            this.state = { stage: 'list' };
+        }
     }
 
     public render() {
         const { nextStage, prevStage } = this;
 
         const props = {
-            ...this.props,
+            countyState: this.props.countyState,
+            currentBallotNumber: this.props.currentBallotNumber,
             nextStage,
             prevStage,
+            totalBallotsForBoard: this.props.totalBallotsForBoard,
         };
 
         switch (this.state.stage) {

--- a/client/src/component/County/AuditBoard/Page.tsx
+++ b/client/src/component/County/AuditBoard/Page.tsx
@@ -11,6 +11,7 @@ import isValidAuditBoard from 'corla/selector/county/isValidAuditBoard';
 
 interface PageProps {
     auditBoardIndex: number;
+    auditBoardStartOrContinue: () => void;
     countyName: string;
 }
 
@@ -36,13 +37,14 @@ class AuditBoardSignInPage extends React.Component<PageProps, PageState> {
 
     public render() {
         const {
-          auditBoardIndex,
-          countyName,
+            auditBoardIndex,
+            auditBoardStartOrContinue,
+            countyName,
         } = this.props;
 
         const submit = () => {
             auditBoardSignIn(auditBoardIndex, this.state.form);
-            window.history.pushState({}, 'login', '/county/audit/' + auditBoardIndex);
+            auditBoardStartOrContinue();
         };
 
         const disableButton = !isValidAuditBoard(this.state.form);

--- a/client/src/component/County/AuditBoard/PageContainer.tsx
+++ b/client/src/component/County/AuditBoard/PageContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { History } from 'history';
+import { RouteComponentProps } from 'react-router-dom';
 
 import withState from 'corla/component/withState';
 import withSync from 'corla/component/withSync';
@@ -15,13 +15,15 @@ import countyInfoSelector from 'corla/selector/county/countyInfo';
 import hasAuditedAnyBallotSelector from 'corla/selector/county/hasAuditedAnyBallot';
 
 
-interface ContainerProps {
+interface MatchParams {
+    id: string;
+}
+
+interface ContainerProps extends RouteComponentProps<MatchParams> {
     auditBoards: AuditBoards;
     countyName: string;
     countyState: County.AppState;
     hasAuditedAnyBallot: boolean;
-    history: History;
-    match: any;
 }
 
 class AuditBoardSignInContainer extends React.Component<ContainerProps> {

--- a/client/src/component/County/AuditBoard/PageContainer.tsx
+++ b/client/src/component/County/AuditBoard/PageContainer.tsx
@@ -44,10 +44,10 @@ class AuditBoardSignInContainer extends React.Component<ContainerProps> {
             countyState,
         );
 
-        if (auditBoardSignedIn) {
-            const auditBoardStartOrContinue = () =>
-                history.push('/county/audit/' + boardIndex);
+        const auditBoardStartOrContinue = () =>
+            history.push('/county/audit/' + boardIndex);
 
+        if (auditBoardSignedIn) {
             return (
                 <SignedInPage auditBoardStatus={ auditBoards[boardIndex] }
                               auditBoardIndex={ boardIndex }
@@ -58,6 +58,7 @@ class AuditBoardSignInContainer extends React.Component<ContainerProps> {
         }
 
         return <AuditBoardPage auditBoardIndex={ boardIndex }
+                               auditBoardStartOrContinue={ auditBoardStartOrContinue }
                                countyName={ countyName } />;
     }
 }

--- a/client/src/component/County/AuditBoard/SignedInPage.tsx
+++ b/client/src/component/County/AuditBoard/SignedInPage.tsx
@@ -8,7 +8,7 @@ import auditBoardSignOut from 'corla/action/county/auditBoardSignOut';
 interface PageProps {
     auditBoardStatus: AuditBoardStatus;
     auditBoardIndex: number;
-    auditBoardStartOrContinue: OnClick;
+    auditBoardStartOrContinue: () => void;
     countyName: string;
     hasAuditedAnyBallot: boolean;
 }

--- a/client/src/component/County/Dashboard/BallotManifest/Form.tsx
+++ b/client/src/component/County/Dashboard/BallotManifest/Form.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { EditableText } from '@blueprintjs/core';
+import { EditableText, FileUpload, FormGroup } from '@blueprintjs/core';
 
 
 interface FormProps {
@@ -47,26 +47,18 @@ const BallotManifestForm = (props: FormProps) => {
     return (
         <div className='pt-card'>
             <div className='pt-card'>
-                <div className='pt-ui-text-large'>
-                    Ballot Manifest
+                <div style={{ width: '600px' }}>
+                    <FormGroup label={ <span className='pt-ui-text-large'>Ballot Manifest</span> }>
+                        <FileUpload fill={ true } text={ fileName } onInputChange={ onFileChange } />
+                    </FormGroup>
+                    <FormGroup label={ <span className='pt-ui-text-large'>SHA-256 hash for Ballot Manifest</span> }>
+                        <EditableText className='pt-input'
+                                      minWidth={ 600 }
+                                      maxLength={ 64 }
+                                      value={ hash }
+                                      onChange={ onHashChange } />
+                    </FormGroup>
                 </div>
-                <label className='pt-file-upload truncate'>
-                    <input type='file' onChange={ onFileChange } />
-                    <span className='pt-file-upload-input'>{ fileName }</span>
-                </label>
-            </div>
-            <div className='pt-card'>
-                <div className='pt-ui-text-large'>
-                   SHA-256 hash for Ballot Manifest
-                </div>
-                <label>
-                    <EditableText
-                        className='pt-input'
-                        minWidth={ 500 }
-                        maxLength={ 64 }
-                        value={ hash }
-                        onChange={ onHashChange } />
-                </label>
             </div>
             { renderedCancelButton }
             <button className='pt-button pt-intent-primary' onClick={ upload }>

--- a/client/src/component/County/Dashboard/CVRExport/Form.tsx
+++ b/client/src/component/County/Dashboard/CVRExport/Form.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { EditableText } from '@blueprintjs/core';
+import { EditableText, FileUpload, FormGroup } from '@blueprintjs/core';
 
 
 interface FormProps {
@@ -47,26 +47,18 @@ const CVRExportForm = (props: FormProps) => {
     return (
         <div className='pt-card'>
             <div className='pt-card'>
-                <div className='pt-ui-text-large'>
-                   CVR Export
+                <div style={{ width: '600px' }}>
+                    <FormGroup label={ <span className='pt-ui-text-large'>CVR Export</span> }>
+                        <FileUpload fill={ true } text={ fileName } onInputChange={ onFileChange } />
+                    </FormGroup>
+                    <FormGroup label={ <span className='pt-ui-text-large'>SHA-256 hash for CVR Export</span> }>
+                        <EditableText className='pt-input'
+                                      minWidth={ 600 }
+                                      maxLength={ 64 }
+                                      value={ hash }
+                                      onChange={ onHashChange } />
+                    </FormGroup>
                 </div>
-                <label className='pt-file-upload truncate'>
-                    <input type='file' onChange={ onFileChange } />
-                    <span className='pt-file-upload-input'>{ fileName }</span>
-                </label>
-            </div>
-            <div className='pt-card'>
-                <div className='pt-ui-text-large'>
-                   SHA-256 hash for CVR Export
-                </div>
-                <label>
-                    <EditableText
-                        className='pt-input'
-                        minWidth={ 500 }
-                        maxLength={ 64 }
-                        value={ hash }
-                        onChange={ onHashChange } />
-                </label>
             </div>
             { renderedCancelButton }
             <button className='pt-button pt-intent-primary' onClick={ upload }>

--- a/client/src/component/County/Dashboard/Main.tsx
+++ b/client/src/component/County/Dashboard/Main.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 
 import { History } from 'history';
 
+import action from 'corla/action';
+
 import AuditBoardNumberSelector from 'corla/component/County/Dashboard/AuditBoardNumberSelector';
 
 import FileUploadContainer from './FileUploadContainer';
@@ -41,7 +43,8 @@ const AuditBoardButtons = (props: AuditBoardButtonsProps) => {
         }
 
         if (canRedirect) {
-          history.push('/county/board/' + boardIndex);
+            action('SET_AUDIT_BOARD', { auditBoardIndex: boardIndex });
+            history.push('/county/board/' + boardIndex);
         }
     };
 

--- a/client/src/component/County/Dashboard/PageContainer.tsx
+++ b/client/src/component/County/Dashboard/PageContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { History } from 'history';
+import { RouteComponentProps } from 'react-router-dom';
 
 import withCountyState from 'corla/component/withCountyState';
 import withPoll from 'corla/component/withPoll';
@@ -22,7 +22,11 @@ import currentRoundNumberSelector from 'corla/selector/county/currentRoundNumber
 import missedDeadlineSelector from 'corla/selector/county/missedDeadline';
 
 
-interface DashboardProps {
+interface MatchParams {
+    id: string;
+}
+
+interface DashboardProps extends RouteComponentProps<MatchParams> {
     allRoundsComplete: boolean;
     auditComplete: boolean;
     auditStarted: boolean;
@@ -32,8 +36,6 @@ interface DashboardProps {
     contests: County.ContestDefs;
     countyState: County.AppState;
     currentRoundNumber: number;
-    history: History;
-    match: any;
     missedDeadline: boolean;
 }
 

--- a/client/src/component/NavMenu.tsx
+++ b/client/src/component/NavMenu.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
+import { IconName, Menu, MenuDivider, MenuItem, } from '@blueprintjs/core';
 import { Link } from 'react-router-dom';
 
 
 interface NavItemProps {
     path: string;
-    iconName: string;
+    iconName: IconName;
     text: string;
 }
 

--- a/client/src/component/NavMenu.tsx
+++ b/client/src/component/NavMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { IconName, Menu, MenuDivider, MenuItem, } from '@blueprintjs/core';
+import { IconName, Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
 import { Link } from 'react-router-dom';
 
 

--- a/client/src/reducer/county/dashboardRefreshOk.ts
+++ b/client/src/reducer/county/dashboardRefreshOk.ts
@@ -2,37 +2,6 @@ import { isEmpty, merge } from 'lodash';
 
 import { parse } from 'corla/adapter/countyDashboardRefresh';
 
-/*
- * XXX: Audit board index hack
- *
- * We ran out of time to get this working the "right" way which would have
- * involved a session and the server knowing which board was currently signed
- * in. Because this state information is overwritten by dashboard refresh
- * responses, we need to shim in the client's idea of the current audit board
- * just before we merge the response into the local application state, which
- * this function helps us to do.
- *
- * We don't get access to component-local state from reducers, so we can't
- * simply read it out of the component either. There is a better way to do this
- * involving an action emitted from the button that the audit board selects to
- * sign in which sets some state that is not overwritten by dashboard refresh
- * responses, but this method suffices for the time being and is at least
- * localized to this place in the code, and can be replaced with a better method
- * in the future without cascading changes.
- *
- * This method retains the benefit of allowing users to sign in multiple audit
- * boards in the same browser session, because the state is held in the URL.
- */
-const auditBoardIndexFromUrl = () => {
-    const re = /^\/county\/board\/(\d+)$/;
-    const matches = window.location.pathname.match(re);
-
-    if (!matches) {
-      return null;
-    }
-
-    return matches[1];
-};
 
 export default function dashboardRefreshOk(
     state: County.AppState,
@@ -50,12 +19,6 @@ export default function dashboardRefreshOk(
     // rounds.
     nextState.auditBoards = newState.auditBoards;
     nextState.currentRound = newState.currentRound;
-
-    // XXX: Audit board index hack
-    const auditBoardIndex = auditBoardIndexFromUrl();
-    if (auditBoardIndex) {
-      nextState.auditBoardIndex = parseInt(auditBoardIndex, 10);
-    }
 
     return nextState;
 }

--- a/client/src/reducer/county/dashboardRefreshOk.ts
+++ b/client/src/reducer/county/dashboardRefreshOk.ts
@@ -2,12 +2,15 @@ import { isEmpty, merge } from 'lodash';
 
 import { parse } from 'corla/adapter/countyDashboardRefresh';
 
+import { countyState } from 'corla/reducer/defaultState';
+
 
 export default function dashboardRefreshOk(
     state: County.AppState,
     action: Action.CountyDashboardRefreshOk,
 ): County.AppState {
     const newState = parse(action.data, state);
+    const defaultState = countyState();
 
     // If it becomes null it will not get overwritten.
     delete state.auditBoardCount;
@@ -19,6 +22,12 @@ export default function dashboardRefreshOk(
     // rounds.
     nextState.auditBoards = newState.auditBoards;
     nextState.currentRound = newState.currentRound;
+
+    // Explicitly reset final review state if we get a dashboard refresh, this
+    // handles cases where users navigate back to the main county page as well
+    // as sending the user back to the final review page when a CVR is
+    // uploaded, assuming there are no more ballots to audit.
+    nextState.finalReview = defaultState.finalReview;
 
     return nextState;
 }

--- a/client/src/reducer/county/fetchCvrOk.ts
+++ b/client/src/reducer/county/fetchCvrOk.ts
@@ -28,19 +28,21 @@ const parse = (data: JSON.CVR, state: AppState): County.CurrentBallot => ({
     submitted: false,
 });
 
-
-export default function fetchCvrOk(
+const fetchCvrOk = (
     state: County.AppState,
     action: Action.CountyFetchCvrOk,
-): County.AppState {
+): County.AppState => {
     const nextState = merge({}, state);
 
     const currentBallot = parse(action.data, state);
     nextState.currentBallot = currentBallot;
 
-    if (!nextState.acvrs[currentBallot.id]) {
-        nextState.acvrs[currentBallot.id] = createEmptyAcvr(currentBallot);
-    }
+    // Always overwrite the corresponding ACVR after a new CVR is fetched. We do
+    // not want an audit board to be influenced by a previous interpretation.
+    nextState.acvrs[currentBallot.id] = createEmptyAcvr(currentBallot);
 
     return nextState;
-}
+};
+
+
+export default fetchCvrOk;

--- a/client/src/reducer/county/reAuditCvr.ts
+++ b/client/src/reducer/county/reAuditCvr.ts
@@ -1,0 +1,9 @@
+export default (state: County.AppState, action: Action.App) => {
+    const nextState = { ...state };
+    const { comment, cvrId } = action.data;
+
+    nextState.finalReview.comment = comment;
+    nextState.finalReview.ballotId = cvrId;
+
+    return nextState;
+};

--- a/client/src/reducer/defaultState.ts
+++ b/client/src/reducer/defaultState.ts
@@ -15,6 +15,9 @@ export function countyState(): County.AppState {
             state: 'NOT_ATTEMPTED',
             timestamp: new Date(),
         },
+        finalReview: {
+            complete: false,
+        },
         rounds: [],
         type: 'County',
     };

--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -8,6 +8,7 @@ import fetchCountyASMStateOk from './county/fetchCountyASMStateOk';
 import countyFetchCvrOk from './county/fetchCvrOk';
 import fetchCvrsToAuditOk from './county/fetchCvrsToAuditOk';
 import countyLoginOk from './county/loginOk';
+import reAuditCvr from './county/reAuditCvr';
 import updateAcvrForm from './county/updateAcvrForm';
 import uploadAcvrOk from './county/uploadAcvrOk';
 import uploadBallotManifestOk from './county/uploadBallotManifestOk';
@@ -108,6 +109,10 @@ export default function root(state: AppState, action: Action.App) {
         return login1FOk(state as LoginAppState, action);
     }
 
+    case 'RE_AUDIT_CVR': {
+        return reAuditCvr(state as County.AppState, action);
+    }
+
     case 'SET_AUDIT_BOARD': {
         const nextState = { ...state } as County.AppState;
 
@@ -176,6 +181,14 @@ export default function root(state: AppState, action: Action.App) {
         const nextState = { ...state } as County.AppState;
 
         nextState.cvrImportPending.alerted = true;
+
+        return nextState;
+    }
+
+    case 'FINAL_REVIEW_COMPLETE': {
+        const nextState = { ...state } as County.AppState;
+
+        nextState.finalReview.complete = true;
 
         return nextState;
     }

--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -108,6 +108,16 @@ export default function root(state: AppState, action: Action.App) {
         return login1FOk(state as LoginAppState, action);
     }
 
+    case 'SET_AUDIT_BOARD': {
+        const nextState = { ...state } as County.AppState;
+
+        const { auditBoardIndex } = action.data;
+
+        nextState.auditBoardIndex = auditBoardIndex;
+
+        return nextState;
+    }
+
     case 'UPDATE_ACVR_FORM': {
         return updateAcvrForm(state as County.AppState, action);
     }

--- a/client/src/saga/county/dashboardRefreshOkSaga.ts
+++ b/client/src/saga/county/dashboardRefreshOkSaga.ts
@@ -15,6 +15,14 @@ import fetchCvrsToAudit from 'corla/action/county/fetchCvrsToAudit';
 import { parse } from 'corla/adapter/countyDashboardRefresh';
 
 
+function nextBallotId(state: County.AppState): number | undefined {
+    if (state.ballotUnderAuditIds && state.auditBoardIndex != null) {
+        return state.ballotUnderAuditIds[state.auditBoardIndex];
+    }
+
+    return;
+}
+
 function* countyRefreshOk({ data }: any): any {
     const state = yield select();
 
@@ -41,7 +49,7 @@ function* countyRefreshOk({ data }: any): any {
         return;
     }
 
-    const nextId = state.ballotUnderAuditIds[state.auditBoardIndex];
+    const nextId = nextBallotId(state);
 
     if (!nextId) {
         return;

--- a/client/src/saga/county/reAuditCvrSaga.ts
+++ b/client/src/saga/county/reAuditCvrSaga.ts
@@ -1,0 +1,17 @@
+import { takeLatest } from 'redux-saga/effects';
+
+import fetchCvr from 'corla/action/county/fetchCvr';
+
+
+function* loadCvr(action: Action.App) {
+    const { cvrId } = action.data;
+
+    yield fetchCvr(cvrId);
+}
+
+function* reAuditCvrSaga() {
+    yield takeLatest('RE_AUDIT_CVR', loadCvr);
+}
+
+
+export default reAuditCvrSaga;

--- a/client/src/saga/root.ts
+++ b/client/src/saga/root.ts
@@ -6,6 +6,7 @@ import acvrUploadSaga from './county/acvrUploadSaga';
 import auditBoardSignInSaga from './county/auditBoardSignInSaga';
 import ballotNotFoundOkSaga from './county/ballotNotFoundOkSaga';
 import countyDashboardRefreshOkSaga from './county/dashboardRefreshOkSaga';
+import reAuditCvrSaga from './county/reAuditCvrSaga';
 import countySyncSaga from './county/sync';
 import uploadAcvrOkSaga from './county/uploadAcvrOkSaga';
 import uploadBallotManifestSaga from './county/uploadBallotManifestSaga';
@@ -32,6 +33,7 @@ export default function* rootSaga() {
         dosSyncSaga(),
         loginSaga(),
         logoutSaga(),
+        reAuditCvrSaga(),
         syncSaga(),
         uploadAcvrOkSaga(),
         uploadBallotManifestSaga(),

--- a/client/src/selector/county/canAudit.ts
+++ b/client/src/selector/county/canAudit.ts
@@ -1,14 +1,5 @@
-import auditBoardSignedIn from './auditBoardSignedIn';
-
-
 function canAudit(state: County.AppState) {
     return state.asm.county === 'COUNTY_AUDIT_UNDERWAY';
-
-    // TODO: Do we need to test auditBoardSignedIn?
-    /*
-    return auditBoardSignedIn(state)
-        && state.asm.county === 'COUNTY_AUDIT_UNDERWAY';
-    */
 }
 
 

--- a/client/src/selector/county/currentBallotNumber.ts
+++ b/client/src/selector/county/currentBallotNumber.ts
@@ -1,31 +1,43 @@
 import * as _ from 'lodash';
 
 
-function currentBallotNumber(state: County.AppState): Option<number> {
+// TODO: Consider another home for this
+//
+// Project an audit-board-specific view of the overall CVRs to audit.
+export const auditBoardSlice = (
+    cvrsToAudit: JSON.CVR[] | undefined,
+    ballotSequenceAssignment: object[] | undefined,
+    auditBoardIndex: number | undefined,
+) => {
+    const bsa: any = _.nth(ballotSequenceAssignment, auditBoardIndex);
+
+    if (!bsa) {
+      return [];
+    }
+
+    const { index, count } = bsa;
+
+    return _.slice(cvrsToAudit, index, index + count);
+};
+
+function currentBallotNumber(state: County.AppState): number | undefined {
     const { auditBoardIndex,
             ballotSequenceAssignment,
             cvrsToAudit,
             currentBallot } = state;
 
-    // Project an audit-board-specific view of the overall CVRs to audit.
-    const auditBoardSlice = () => {
-        const bsa: any = _.nth(ballotSequenceAssignment, auditBoardIndex);
+    if (typeof auditBoardIndex !== 'number') { return undefined; }
+    if (!ballotSequenceAssignment) { return undefined; }
+    if (!cvrsToAudit) { return undefined; }
+    if (!currentBallot) { return undefined; }
 
-        if (!bsa) {
-          return [];
-        }
+    const slice = auditBoardSlice(
+        cvrsToAudit,
+        ballotSequenceAssignment,
+        auditBoardIndex,
+    );
 
-        const { index, count } = bsa;
-
-        return _.slice(cvrsToAudit, index, index + count);
-    };
-
-    if (typeof auditBoardIndex !== 'number') { return null; }
-    if (!ballotSequenceAssignment) { return null; }
-    if (!cvrsToAudit) { return null; }
-    if (!currentBallot) { return null; }
-
-    return 1 + _.findIndex(auditBoardSlice(), cvr => {
+    return 1 + _.findIndex(slice, cvr => {
         return cvr.db_id === currentBallot.id;
     });
 }

--- a/client/src/selector/county/totalBallotsForBoard.ts
+++ b/client/src/selector/county/totalBallotsForBoard.ts
@@ -1,11 +1,11 @@
 import * as _ from 'lodash';
 
 
-function totalBallotsForBoard(state: County.AppState): Option<number> {
+function totalBallotsForBoard(state: County.AppState): number | undefined {
     const { auditBoardIndex, ballotSequenceAssignment } = state;
 
-    if (typeof auditBoardIndex !== 'number') { return null; }
-    if (!ballotSequenceAssignment) { return null; }
+    if (typeof auditBoardIndex !== 'number') { return undefined; }
+    if (!ballotSequenceAssignment) { return undefined; }
 
     const bsa: any = _.nth(ballotSequenceAssignment, auditBoardIndex);
 


### PR DESCRIPTION
Resolves: [#163164230](https://www.pivotaltracker.com/story/show/163164230), [#163164277](https://www.pivotaltracker.com/story/show/163164277)

An audit board member may want to change the ballot interpretation before signing off on a round if they realize they have been making interpretation mistakes or if they could not find a ballot card initially, but it was later found before the round was over.

Audit board members are not allowed to see their previous entries to avoid biasing their results - they must re-interpret the ballot. They must also include a comment which will become part of the audit record, and the system will continue to store all previous interpretations along with the older comments.

This PR must be merged after the corresponding API component is finished.