### PR TITLE
Fix sorting to accommodate numeric strings naturally

### DIFF
--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,3 +1,27 @@
+import * as _ from 'lodash';
+
+
 export function empty() {
     return {};
+}
+
+/**
+ * "Natural" sorting with support for numbers within strings.
+ *
+ * Numbers are sorted numerically rather than lexicographically, so "4" will
+ * come before "10".
+ */
+export function naturalSortBy<T>(
+    collection: T[],
+    selector: (x: T) => any,
+) {
+    const intlComparator = new Intl.Collator('en', {
+        numeric: true,
+    }).compare;
+
+    const comparator = (a: T, b: T): number =>
+        intlComparator(selector(a), selector(b));
+
+    // Array.prototype.sort is in-place
+    return _.map(collection).sort(comparator);
 }


### PR DESCRIPTION
Resolves [#163591819](https://www.pivotaltracker.com/story/show/163591819).

Uses `Intl.Collator` comparator with built-in numeric sorting to accomplish the task. This has been supported in all major browsers since IE 11.