### PR TITLE
Refresh dashboard after audit board count set

### DIFF
--- a/client/src/component/County/AuditBoard/PageContainer.tsx
+++ b/client/src/component/County/AuditBoard/PageContainer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-
 import { RouteComponentProps } from 'react-router-dom';
+
+import * as _ from 'lodash';
 
 import withState from 'corla/component/withState';
 import withSync from 'corla/component/withSync';
@@ -72,7 +73,7 @@ interface SelectProps {
 
 function select(countyState: County.AppState): SelectProps {
     const countyInfo = countyInfoSelector(countyState);
-    const countyName = countyInfo!.name || '';
+    const countyName = _.get(countyInfo, 'name', '');
 
     return {
         auditBoards: countyState.auditBoards,

--- a/client/src/component/County/Dashboard/AuditBoardNumberSelector.tsx
+++ b/client/src/component/County/Dashboard/AuditBoardNumberSelector.tsx
@@ -115,6 +115,6 @@ class AuditBoardNumberSelector
 
 const mapDispatchToProps = () => {
     return { setNumberOfAuditBoards };
-}
+};
 
 export default connect(null, mapDispatchToProps)(AuditBoardNumberSelector);

--- a/client/src/component/County/Dashboard/AuditBoardNumberSelector.tsx
+++ b/client/src/component/County/Dashboard/AuditBoardNumberSelector.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 
 import { NumericInput } from '@blueprintjs/core';
 
 import setNumberOfAuditBoards from 'corla/action/county/setNumberOfAuditBoards';
-
 
 /**
  * Minimum number of audit boards that can participate.
@@ -15,6 +15,7 @@ interface AuditBoardNumberSelectorProps {
     numberOfBallotsToAudit?: number;
     isShown: boolean;
     isEnabled: boolean;
+    setNumberOfAuditBoards: (x: { auditBoardCount: number }) => void;
 }
 
 interface AuditBoardNumberSelectorState {
@@ -87,7 +88,7 @@ class AuditBoardNumberSelector
         const { auditBoardCount } = this.state;
 
         this.setState({ isEnabled: false });
-        setNumberOfAuditBoards({ auditBoardCount });
+        this.props.setNumberOfAuditBoards({ auditBoardCount });
     }
 
     private helperText(toAudit?: number) {
@@ -112,4 +113,8 @@ class AuditBoardNumberSelector
     }
 }
 
-export default AuditBoardNumberSelector;
+const mapDispatchToProps = () => {
+    return { setNumberOfAuditBoards };
+}
+
+export default connect(null, mapDispatchToProps)(AuditBoardNumberSelector);

--- a/client/src/saga/county/dashboardRefreshOkSaga.ts
+++ b/client/src/saga/county/dashboardRefreshOkSaga.ts
@@ -1,10 +1,6 @@
 import { has } from 'lodash';
 
-import {
-    put,
-    select,
-    takeLatest,
-} from 'redux-saga/effects';
+import { call, put, select, takeLatest } from 'redux-saga/effects';
 
 import notice from 'corla/notice';
 
@@ -48,11 +44,11 @@ function* countyRefreshOk({ data }: any): any {
     const county = parse(data, state);
 
     if (county.id) {
-        countyFetchContests(county.id);
+        yield call(countyFetchContests, county.id);
     }
 
     if (has(county, 'currentRound.number')) {
-        fetchCvrsToAudit(county.currentRound!.number);
+        yield call(fetchCvrsToAudit, county.currentRound!.number);
     }
 
     if (typeof state.auditBoardIndex !== 'number') {
@@ -72,7 +68,7 @@ function* countyRefreshOk({ data }: any): any {
         // it is new. Otherwise we already have it, and fetching it
         // again would overwrite the `submitted` flag, causing us to
         // forget that we are waiting for the submission to be handled.
-        countyFetchCvr(nextId);
+        yield call(countyFetchCvr, nextId);
     }
 }
 

--- a/client/src/saga/sync.ts
+++ b/client/src/saga/sync.ts
@@ -1,7 +1,4 @@
-import {
-    put,
-    takeLatest,
-} from 'redux-saga/effects';
+import { all, call, takeLatest } from 'redux-saga/effects';
 
 import countyDashboardRefresh from 'corla/action/county/dashboardRefresh';
 import fetchAuditBoardASMState from 'corla/action/county/fetchAuditBoardASMState';
@@ -10,26 +7,29 @@ import fetchCountyASMState from 'corla/action/county/fetchCountyASMState';
 import dosDashboardRefresh from 'corla/action/dos/dashboardRefresh';
 import dosFetchContests from 'corla/action/dos/fetchContests';
 
-
-function countyRefresh() {
-    countyDashboardRefresh();
-    fetchAuditBoardASMState();
-    fetchCountyASMState();
+function* countyRefresh() {
+    yield all([
+        call(countyDashboardRefresh),
+        call(fetchAuditBoardASMState),
+        call(fetchCountyASMState),
+    ]);
 }
 
-function dosRefresh() {
-    dosDashboardRefresh();
-    dosFetchContests();
+function* dosRefresh() {
+    yield all([
+        call(dosDashboardRefresh),
+        call(dosFetchContests),
+    ]);
 }
 
-
-export default function* dosLoginSaga() {
+export default function* syncSaga() {
     const countyRefreshActions = [
         'AUDIT_BOARD_SIGN_IN_OK',
         'AUDIT_BOARD_SIGN_OUT_OK',
         'BALLOT_NOT_FOUND_FAIL',
         'BALLOT_NOT_FOUND_NETWORK_FAIL',
         'BALLOT_NOT_FOUND_OK',
+        'SET_NUMBER_OF_AUDIT_BOARDS_OK',
         'SUBMIT_ROUND_SIGN_OFF_OK',
         'UPLOAD_ACVR_FAIL',
         'UPLOAD_ACVR_NETWORK_FAIL',


### PR DESCRIPTION
Resolves [#163605107](https://www.pivotaltracker.com/story/show/163605107).

I also caught a spot where we were sending a duplicate network request for the contests, which should be a nice overall speedup.

The saga refactoring is so we do a better job of following redux-saga idioms, which facilitate:

- Generator testability: by yielding effect descriptions you can test what a generator should be doing without causing it to invoke its actions
- Allowing called functions to return Promises in the future

**Wait until `re-audit` is merged before rebasing and merging.**