### PR TITLE
[api] change storage location sort so first diff counts, not last

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/util/NaturalOrderComparator.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/util/NaturalOrderComparator.java
@@ -93,7 +93,7 @@ public final class NaturalOrderComparator implements Comparator<String>, Seriali
     final Iterator<String> as = split(an_a).iterator();
     final Iterator<String> bs = split(an_b).iterator();
 
-    while (as.hasNext() && bs.hasNext()) {
+    while (as.hasNext() && bs.hasNext() && result == 0) {
       final String x = as.next();
       final String y = bs.next();
 
@@ -101,6 +101,14 @@ public final class NaturalOrderComparator implements Comparator<String>, Seriali
         result = compareAsDigits(x, y);
       } else {
         result = String.CASE_INSENSITIVE_ORDER.compare(x, y);
+
+        // take the opposite because we want the lower char number A to come
+        // before the larger char number B. Also, not greater than one for consistency
+        if (result > 0) {
+          result = -1;
+        } else if (result < 0) {
+          result = 1;
+        }// else result is zero, and that is fine
       }
     }
 

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/util/NaturalOrderComparatorTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/util/NaturalOrderComparatorTest.java
@@ -19,5 +19,19 @@ public class NaturalOrderComparatorTest {
       assertEquals(c.compare("Batch 11", "Batch 2"), 1);
       assertEquals(c.compare("Batch 20", "batch 19"), 1);
       assertEquals(c.compare("Batch 123", "Batch 123.a"), -1);
+      assertEquals(c.compare("Batch A", "Batch b"), 1);
   }
+
+
+  @Test()
+  public void compareDatesTest() {
+    assertEquals(c.compare("Feb 12, 2019, 10:22 am", "Feb 12, 2019, 10:22 am"), 0, "match");
+    assertEquals(c.compare("Feb 12, 2019, 10:22 am", "Feb 12, 2019, 10:23 am"), -1, "1 minute later");
+    assertEquals(c.compare("Feb 13, 2019, 10:22 am", "Feb 12, 2019, 10:23 am"), 1, "1 day earlier");
+    assertEquals(c.compare("Feb 13, 2019, 10:22 am", "Feb 12, 2019, 10:23 pm"), 1, "am before pm");
+    assertEquals(c.compare("Feb 13, 2019, 10:22 am", "Aug 12, 2019, 10:22 pm"), -1,
+                 " Aug before Feb because it is a string comparison not a date comparison");
+  }
+
+
 }


### PR DESCRIPTION
I thought it was weird that dates wouldn't work as sort-able values of storage locations.  With this they would.