### PR TITLE
[ui] skip standardization pages if a file is not given

### DIFF
--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
@@ -80,6 +80,9 @@ const StandardizeContestsPageContainer = (props: Props) => {
         if (_.isEmpty(filteredContests)) {
             return <Redirect to={ NEXT_PATH } />;
         }
+    } else {
+        // it is ok to skip this whole step
+        return <Redirect to='/sos/audit/select-contests' />;
     }
 
     return <StandardizeContestsPage areContestsLoaded={ areContestsLoaded }

--- a/client/src/component/DOS/DefineAudit/StartPage.tsx
+++ b/client/src/component/DOS/DefineAudit/StartPage.tsx
@@ -49,7 +49,6 @@ const SaveButton = (props: SaveButtonProps) => {
         if (!forms.electionDateForm) { return; }
         if (!forms.electionTypeForm) { return; }
         if (!forms.publicMeetingDateForm) { return; }
-        if (!forms.uploadFile) { return; }
 
         if (!forms.electionDateForm.date) { return; }
         if (!forms.electionTypeForm.type) { return; }
@@ -62,7 +61,11 @@ const SaveButton = (props: SaveButtonProps) => {
         if (!forms.riskLimit) { return; }
         const riskLimit = forms.riskLimit.comparisonLimit;
 
-        const uploadFile = forms.uploadFile.files.map((file: any) => file);
+        let uploadFile = [];
+
+        if (forms.uploadFile && forms.uploadFile.files) {
+            uploadFile = forms.uploadFile.files.map((file: any) => file);
+        }
 
         setAuditInfo({
             election: {


### PR DESCRIPTION
Shortcuts taken to skip the standardize contests and choices pages. It is not required and this will remove need for the awkward dummy file workaround. 