### PR TITLE
[api] fix reaudit end of round bug

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -216,6 +216,7 @@ public final class ComparisonAuditController {
 
     final Integer new_count = audit(cdb, cai, true);
     LOGGER.debug("[reaudit] new_count: " + new_count.toString());
+    cdb.updateAuditStatus();
 
     return true;
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SignOffAuditRound.java
@@ -270,6 +270,9 @@ public class SignOffAuditRound extends AbstractAuditBoardDashboardEndpoint {
     for (final CountyDashboard cdb : Persistence.getAll(CountyDashboard.class)) {
       if (cdb.id().equals(the_id)) {
         continue; // <- sneaky filter for all but this county
+        // ROUND_COMPLETE_EVENT has already happened for this county above, and
+        // the notifyAuditComplete will handle COUNTY_AUDIT_COMPLETE_EVENT for
+        // this county
       }
 
       if (!cdb.id().equals(the_id)) {
@@ -326,10 +329,6 @@ public class SignOffAuditRound extends AbstractAuditBoardDashboardEndpoint {
     }
     if (all_complete) {
       ASMUtilities.step(DOS_AUDIT_COMPLETE_EVENT,
-                        DoSDashboardASM.class,
-                        DoSDashboardASM.IDENTITY);
-    } else {
-      ASMUtilities.step(DOS_COUNTY_AUDIT_COMPLETE_EVENT,
                         DoSDashboardASM.class,
                         DoSDashboardASM.IDENTITY);
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
@@ -328,8 +328,6 @@ public class StartAuditRound extends AbstractDoSDashboardEndpoint {
       // the ASM states, and false otherwise as we just assume audit
       // reasonableness in the absence of ASMs. We'll remind you about
       // it at the end.
-      boolean audit_complete = true;
-
       // FIXME map a function over a collection of dashboardsToStart
       // FIXME extract-fn (for days): update every county dashboard with
       // a list of ballots to audit
@@ -422,11 +420,6 @@ public class StartAuditRound extends AbstractDoSDashboardEndpoint {
                             String.valueOf(cdb.id()));
           ASMUtilities.save(countyDashboardASM);
 
-          // figure out whether this county is done, or whether there's
-          // an audit to run (audit_complete is initially true, so if
-          // any dashboards are NOT in a final state, we're not done.
-          audit_complete &= countyDashboardASM.isInFinalState();
-
         // FIXME hoist me; we don't need to know about HTTP requests or
         // responses at this level.
         } catch (final IllegalArgumentException e) {
@@ -441,16 +434,7 @@ public class StartAuditRound extends AbstractDoSDashboardEndpoint {
         }
       } // end of dashboard twiddling
 
-      // At this point, anyone who needed another round should have one.
-      // If everyone is done, we're all done.
-
-      // FIXME hoist me
-      if (audit_complete) {
-        my_event.set(DOS_AUDIT_COMPLETE_EVENT);
-        ok(the_response, "audit complete");
-      } else {
-        ok(the_response, "round started");
-      }
+      ok(the_response, "round started");
       // end of extraction. Now we can talk about HTTP requests / responses again!
     } catch (final PersistenceException e) {
       LOGGER.error("PersistenceException " + e);


### PR DESCRIPTION
There was a bug in reaudit after all. The audit status gets updated to IN_PROGRESS during unaudit and whether all the necessary ballots have been audited needs to get re-evaluated, and then the audit status will be corrected. This is done by calling updateStatus.

I also removed a finalize step from the start of round because that is handled in the sign off step. 