### PR TITLE
Create a separate YourKit server build

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,6 +7,9 @@ POSTGRESQL_TAG ?= latest
 SERVER_REPOSITORY ?= quay.io/democracyworks/rla-server
 SERVER_TAG ?= latest
 
+SERVER_YOURKIT_REPOSITORY ?= quay.io/democracyworks/rla-server
+SERVER_YOURKIT_TAG ?= latest-yourkit
+
 ### Apache httpd
 
 .PHONY: httpd-build httpd-deploy
@@ -45,3 +48,16 @@ server-build:
 
 server-deploy:
 	docker push $(SERVER_REPOSITORY):$(SERVER_TAG)
+
+### RLA server with YourKit
+
+.PHONY: server-yourkit-build server-yourkit-deploy
+
+server-yourkit-build:
+	docker build --pull \
+		-f server-yourkit/Dockerfile \
+		-t $(SERVER_YOURKIT_REPOSITORY):$(SERVER_YOURKIT_TAG) \
+		../
+
+server-yourkit-deploy:
+	docker push $(SERVER_YOURKIT_REPOSITORY):$(SERVER_YOURKIT_TAG)

--- a/docker/server-yourkit/Dockerfile
+++ b/docker/server-yourkit/Dockerfile
@@ -10,10 +10,17 @@ RUN mvn package
 FROM openjdk:8
 LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
 
+RUN wget https://www.yourkit.com/download/docker/YourKit-JavaProfiler-2018.04-docker.zip -P /tmp/ && \
+  unzip /tmp/YourKit-JavaProfiler-2018.04-docker.zip -d /usr/local && \
+  rm /tmp/YourKit-JavaProfiler-2018.04-docker.zip
+
 COPY docker/server/docker.properties /srv/corla/docker.properties
 COPY --from=maven /srv/corla/server/eclipse-project/target/corla-server-*-shaded.jar \
      /srv/corla/corla.jar
 
+EXPOSE 10001
+
 CMD ["java", \
+     "-agentpath:/usr/local/YourKit-JavaProfiler-2018.04/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all", \
      "-jar", "/srv/corla/corla.jar", \
      "/srv/corla/docker.properties"]

--- a/docker/server-yourkit/docker.properties
+++ b/docker/server-yourkit/docker.properties
@@ -1,0 +1,36 @@
+# The default properties file for ColoradoRLA
+http_port = 8888
+https_port = 8889
+locale = en_US
+#keystore = /us/freeandfair/corla/default.jks
+#keystore_password = corla2017
+county_ids = us/freeandfair/corla/county_ids.properties
+# DatabaseAuthentiation or EntrustAuthentication
+authentication_class = us.freeandfair.corla.auth.DatabaseAuthentication
+# if authentication class is using EntrustAuthentication, then we must
+# specify the location of the Entrust server
+# entrust_server_name = localhost
+#
+# parameters for CVR import transaction/batch sizes
+#
+cvr_import_transaction_size = 400
+cvr_import_batch_size = 80
+#
+# parameters for hibernate settings and database settings
+#
+hibernate.driver = org.postgresql.Driver
+hibernate.url = jdbc:postgresql://postgresql:5432/corla?reWriteBatchedInserts=true&disableColumnSantiser=true
+hibernate.user = corla
+hibernate.pass = corla
+hibernate.dialect = org.hibernate.dialect.PostgreSQL9Dialect
+hibernate.hbm2ddl.auto = update
+hibernate.show_sql = false
+hibernate.format_sql = false
+hibernate.use_sql_comments = false
+hibernate.c3p0.min_size = 20
+hibernate.c3p0.max_size = 20
+hibernate.c3p0.timeout = 300
+hibernate.c3p0.max_statements = 0
+hibernate.c3p0.idle_test_period = 0
+
+unix_upload_file_location=/tmp/corla/upload/


### PR DESCRIPTION
Removes YourKit from the default server build. In most cases we do not need YourKit, but this leaves an easy way to use it if we need to.