### PR TITLE
[infra] move ci tests to docker builds

### DIFF
--- a/ci/check-client
+++ b/ci/check-client
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+cd $TRAVIS_BUILD_DIR
 # Exit early if there were no client changes.
-"${TRAVIS_BUILD_DIR}/ci/changes-in-dir" client || exit 0
+.ci/changes-in-dir client || exit 0
 
-cd "${CLIENT_DIR}"
-npm run lint
-npm run pack
-npm test
+docker build -t corla-client -f docker/test/Dockerfile.client client
+
+popd

--- a/ci/check-server
+++ b/ci/check-server
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -eux -o pipefail
 
+cd $TRAVIS_BUILD_DIR
 # Exit early if there were no server changes.
-"${TRAVIS_BUILD_DIR}/ci/changes-in-dir" server || exit 0
+.ci/changes-in-dir server || exit 0
 
-cd "${SERVER_DIR}"
-mvn verify
+docker build -t corla-server -f docker/test/Dockerfile.server server
+
+popd

--- a/docker/test/Dockerfile.client
+++ b/docker/test/Dockerfile.client
@@ -1,0 +1,15 @@
+FROM node:8 as node
+
+WORKDIR /srv/corla/client
+
+COPY package.json /srv/corla/client
+COPY npm-shrinkwrap.json /srv/corla/client/npm-shrinkwrap.json
+
+RUN npm install
+
+# use the client/ dir as context
+COPY . /srv/corla/client
+
+RUN npm run lint
+# modus operandi: if you can build it you can run it
+RUN npm run pack

--- a/docker/test/Dockerfile.server
+++ b/docker/test/Dockerfile.server
@@ -1,0 +1,17 @@
+FROM maven:3.6 as maven
+
+WORKDIR /srv/corla/server/eclipse-project
+
+ADD eclipse-project/pom.xml /srv/corla/server/eclipse-project/pom.xml
+
+# cache the expensive command to download everything
+# RUN mvn dependency:go-offline does not get everything, not sure why this one does:
+RUN mvn -B -e -C -T 1C org.apache.maven.plugins:maven-dependency-plugin:3.0.2:go-offline
+
+# use the client/ dir as context
+ADD eclipse-project /srv/corla/server/eclipse-project
+
+RUN mvn clean
+
+# verify runs test,pwd, and findbugs, so if the image builds, they all passed
+RUN mvn --offline verify

--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -10,6 +10,7 @@
 	<properties>
 	  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	  <corla.test.excludedGroups>integration</corla.test.excludedGroups>
+    <surefire.version>2.22.0</surefire.version>
 	</properties>
 	<build>
 		<directory>target</directory>
@@ -57,7 +58,7 @@
 			<plugin>
 			  <groupId>org.apache.maven.plugins</groupId>
 			  <artifactId>maven-surefire-plugin</artifactId>
-			  <version>2.22.0</version>
+			  <version>${surefire.version}</version>
 			  <configuration>
 			    <excludedGroups>${corla.test.excludedGroups}</excludedGroups>
 			  </configuration>
@@ -252,6 +253,18 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-surefire-plugin</artifactId>
+			<version>${surefire.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.surefire</groupId>
+      <artifactId>surefire-testng</artifactId>
+			<version>${surefire.version}</version>
+      <scope>test</scope>
     </dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This will avoid the need to customize the build kite builders/servers to have all the deps for this project.