### PR TITLE
Add two new statuses to the state dashboard

### DIFF
--- a/client/screen.css
+++ b/client/screen.css
@@ -15,6 +15,7 @@
  * @dark-gray5: #394B59
  *
  * @green3: #0F9960
+ * @red3: #DB3737
  */
 
 /*
@@ -214,6 +215,10 @@ h1, h2, h3, h4, h5, h6 {
   height: 8px;
   width: 8px;
   border-radius: 50%;
+}
+
+.status-indicator.status-indicator-error {
+  background-color: #DB3737;
 }
 
 .status-indicator.status-indicator-in-progress {

--- a/client/src/adapter/dosDashboardRefresh.ts
+++ b/client/src/adapter/dosDashboardRefresh.ts
@@ -68,6 +68,7 @@ function parseCountyStatus(countyStatus: any) {
             asmState: c.asm_state,
             auditBoard: parseAuditBoard(c.audit_board),
             auditBoardASMState: c.audit_board_asm_state,
+            auditBoardCount: c.audit_board_count,
             auditedBallotCount: c.audited_ballot_count,
             ballotManifest: parseFile(c.ballot_manifest_file),
             ballotsRemainingInRound: c.ballots_remaining_in_round,

--- a/client/src/component/DOS/Dashboard/CountyUpdates.tsx
+++ b/client/src/component/DOS/Dashboard/CountyUpdates.tsx
@@ -63,7 +63,7 @@ class CountyUpdates extends React.Component<UpdatesProps, UpdatesState> {
      */
     public static getDerivedStateFromProps(props: UpdatesProps, state: UpdatesState) {
         const uniqueStatuses = _.uniq(_.map(props.countyStatus, c => {
-            return formatCountyAndBoardASMState(c.asmState, c.auditBoardASMState);
+            return formatCountyAndBoardASMState(c);
         }));
 
         const newFilters = _.reduce(uniqueStatuses, (acc, v) => {
@@ -106,8 +106,8 @@ class CountyUpdates extends React.Component<UpdatesProps, UpdatesState> {
         const countyData: RowData[] = _.map(countyStatus, (c): RowData => {
             const county = counties[c.id];
             const missedDeadline = c.asmState === 'DEADLINE_MISSED';
-            const status = formatCountyAndBoardASMState(c.asmState, c.auditBoardASMState);
-            const statusIndicator = formatCountyAndBoardASMStateIndicator(c.asmState, c.auditBoardASMState);
+            const status = formatCountyAndBoardASMState(c);
+            const statusIndicator = formatCountyAndBoardASMStateIndicator(c);
 
             if (!auditStarted || (auditStarted && missedDeadline)) {
                 return {
@@ -119,7 +119,7 @@ class CountyUpdates extends React.Component<UpdatesProps, UpdatesState> {
                     remRound: '—',
                     remTotal: '—',
                     status,
-                    statusIndicator: '',
+                    statusIndicator,
                     submitted: '—',
                 };
             }

--- a/client/src/format.ts
+++ b/client/src/format.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 function capitalize(s: string) {
     if (!s) { return ''; }
 
@@ -33,26 +35,32 @@ export function formatCountyASMState(state: County.ASMState): string {
     }
 }
 
-export function formatCountyAndBoardASMState(
-    county: County.ASMState,
-    board: AuditBoardASMState,
-): string {
-    switch (county) {
+export function formatCountyAndBoardASMState(countyStatus: DOS.CountyStatus): string {
+    const countyAsmState = countyStatus.asmState;
+    const boardAsmState = countyStatus.auditBoardASMState;
+
+    switch (countyAsmState) {
     case 'COUNTY_AUDIT_UNDERWAY': {
-        switch (board) {
+        switch (boardAsmState) {
         case 'AUDIT_INITIAL_STATE':
             // Should not be reachable, given county state.
             return '—';
         case 'WAITING_FOR_ROUND_START':
-            return 'Waiting for round start';
         case 'WAITING_FOR_ROUND_START_NO_AUDIT_BOARD':
-            return 'Waiting for round start';
+            if (countyStatus.auditBoardCount) {
+                return 'Audit board # is set';
+            } else {
+                return 'Waiting for round start';
+            }
         case 'ROUND_IN_PROGRESS':
             return 'Round in progress';
         case 'ROUND_IN_PROGRESS_NO_AUDIT_BOARD':
-            return 'Round in progress';
+            if (countyStatus.auditBoardCount) {
+                return 'Audit board # is set';
+            } else {
+                return 'Round in progress';
+            }
         case 'WAITING_FOR_ROUND_SIGN_OFF':
-            return 'Waiting for round sign-off';
         case 'WAITING_FOR_ROUND_SIGN_OFF_NO_AUDIT_BOARD':
             return 'Waiting for round sign-off';
         case 'AUDIT_COMPLETE':
@@ -71,29 +79,38 @@ export function formatCountyAndBoardASMState(
             return '—';
         }
     }
-    default: return formatCountyASMState(county);
+    default:
+        if (_.get(countyStatus, 'ballotManifest.result.success') === false ||
+            _.get(countyStatus, 'cvrExport.result.success') === false) {
+            return 'File upload failed';
+        } else {
+            return formatCountyASMState(countyAsmState);
+        }
     }
 }
 
 /*
  * Return the CSS class to display an indicator for a given status.
  */
-export function formatCountyAndBoardASMStateIndicator(
-    county: County.ASMState,
-    board: AuditBoardASMState,
-): string {
-    switch (county) {
+export function formatCountyAndBoardASMStateIndicator(countyStatus: DOS.CountyStatus): string {
+    const countyAsmState = countyStatus.asmState;
+    const boardAsmState = countyStatus.auditBoardASMState;
+
+    switch (countyAsmState) {
     case 'COUNTY_AUDIT_UNDERWAY': {
-        switch (board) {
+        switch (boardAsmState) {
         case 'ROUND_IN_PROGRESS':
-            return 'status-indicator-in-progress';
-        case 'ROUND_IN_PROGRESS_NO_AUDIT_BOARD':
             return 'status-indicator-in-progress';
         default:
             return '';
         }
     }
     default:
-        return '';
+        if (_.get(countyStatus, 'ballotManifest.result.success') === false ||
+            _.get(countyStatus, 'cvrExport.result.success') === false) {
+            return 'status-indicator-error';
+        } else {
+            return '';
+        }
     }
 }

--- a/client/src/types/dos.d.ts
+++ b/client/src/types/dos.d.ts
@@ -52,11 +52,12 @@ declare namespace DOS {
         asmState: County.ASMState;
         auditBoard: AuditBoardStatus;
         auditBoardASMState: AuditBoardASMState;
+        auditBoardCount?: number;
         auditedBallotCount: number;
-        ballotManifest: UploadedFile;
+        ballotManifest?: UploadedFile;
         ballotsRemainingInRound: number;
         currentRound: Round;
-        cvrExport: UploadedFile;
+        cvrExport?: UploadedFile;
         disagreementCount: number;
         discrepancyCount: DiscrepancyCount;
         estimatedBallotsToAudit: number;


### PR DESCRIPTION
- When the audit board count is set, display a new status
- When a file upload has failed, display a new status

Resolves: [#166013154](https://www.pivotaltracker.com/story/show/166013154), [#166013270](https://www.pivotaltracker.com/story/show/166013270)