### PR TITLE
Re-style file download widget

### DIFF
--- a/client/screen.css
+++ b/client/screen.css
@@ -192,6 +192,61 @@ h1, h2, h3, h4, h5, h6 {
   max-width: 550px;
 }
 
+/* Uploaded file component */
+
+.uploaded-file {
+  max-width: 750px;
+}
+
+dl.uploaded-file-details {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  overflow: visible;
+}
+
+dl.uploaded-file-details dt {
+  flex: 0 0 20%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  font-weight: bold;
+  margin-top: 10px;
+}
+
+dl.uploaded-file-details dd {
+  flex: 0 0 80%;
+  margin-left: auto;
+  margin-top: 10px;
+  text-align: left;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.uploaded-file-footer {
+  align-items: center;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.uploaded-file-footer-status p:last-child {
+  margin-bottom: 0px;
+}
+
+.uploaded-file-footer-status.pt-callout {
+  background-color: transparent;
+  width: auto;
+}
+
+.uploaded-file-popover .pt-popover-content {
+  padding: 20px;
+}
+
+.uploaded-file-popover-target {
+  cursor: pointer;
+  text-decoration: underline dashed;
+  margin-left: 5px;
+}
+
 /*** State Dashboard ***/
 
 /*

--- a/client/src/component/County/Dashboard/MissedDeadlinePage.tsx
+++ b/client/src/component/County/Dashboard/MissedDeadlinePage.tsx
@@ -1,24 +1,18 @@
-
-
 import * as React from 'react';
 
-import { Card } from '@blueprintjs/core';
+import { Callout } from '@blueprintjs/core';
 
 import CountyLayout from 'corla/component/CountyLayout';
 import * as config from 'corla/config';
 
 const MissedDeadlinePage = () => {
     const main =
-        <div>
-            <h2>Upload Deadline Missed</h2>
-            <div>
-                <Card>
-                    You are unable to upload a file because the deadline has passed and the
-                    audit has begun. Please contact the CDOS voting systems team at&nbsp;
-                    <strong>{ config.helpEmail }</strong> or <strong>{ config.helpTel }</strong> for assistance.
-                </Card>
-            </div>
-        </div>;
+        <Callout icon='info-sign'
+                 title='Upload deadline missed'>
+            You are unable to upload a file because the deadline has passed and the
+            audit has begun. Please contact the CDOS voting systems team at&nbsp;
+            <strong>{ config.helpEmail }</strong> or <strong>{ config.helpTel }</strong> for assistance.
+        </Callout>;
 
     return <CountyLayout main={ main } />;
 };

--- a/client/src/component/FileDownloadButtons.tsx
+++ b/client/src/component/FileDownloadButtons.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, Intent } from '@blueprintjs/core';
+import { Button, Callout, Intent, Popover } from '@blueprintjs/core';
 
 import downloadFile from 'corla/action/downloadFile';
 
@@ -10,10 +10,9 @@ interface UploadedFileProps {
 }
 
 const UploadedFile = ({ description, file }: UploadedFileProps) => {
-
     if (null === file || undefined === file) {
         return (
-            <div className='pt-card'>
+            <div className='uploaded-file mt-default'>
                 <h4>{ description }</h4>
                 <p>Not yet uploaded</p>
             </div>
@@ -22,26 +21,50 @@ const UploadedFile = ({ description, file }: UploadedFileProps) => {
 
         const onClick = () => downloadFile(file.id);
         return (
-            <div className='pt-card'>
+            <div className='uploaded-file mt-default'>
                 <h4>{ description }</h4>
-                <div><strong>File name:</strong> "{ file.fileName }"</div>
-                <div><strong>SHA-256 hash:</strong> { file.hash }</div>
-                <div className='error'>
-                    <strong>{file.result.success ? '' : 'Error Message: ' }</strong>
-                    { file.result.errorMessage }
-                </div>
-                <div className='error rowNum'>
-                    <strong>{file.result.success ? '' : 'Error row number: ' }</strong>
-                    { file.result.errorRowNum }
-                </div>
-                <div className='error rowContent'>
-                    <strong>{file.result.success ? '' : 'Error row content: ' }</strong>
-                    { file.result.errorRowContent }
-                </div>
-                <Button intent={ Intent.PRIMARY }
-                        onClick={ onClick }>
-                    Download
-                </Button>
+                <dl className='uploaded-file-details'>
+                    <dt>File name</dt>
+                    <dd>{ file.fileName }</dd>
+
+                    <dt>SHA-256 hash</dt>
+                    <dd>{ file.hash }</dd>
+                </dl>
+                <Callout className='uploaded-file-footer'>
+                    { file.result.success ?
+                        <Callout className='uploaded-file-footer-status'
+                                 intent={ Intent.SUCCESS }
+                                 icon='tick-circle'>
+                            File successfully uploaded
+                        </Callout> :
+                        <Callout className='uploaded-file-footer-status'
+                                 intent={ Intent.DANGER }
+                                 icon='error'>
+                            <p>
+                                <strong>Error: </strong>
+                                { file.result.errorMessage ? file.result.errorMessage : 'unknown' }
+                                { file.result.errorRowNum &&
+                                    <Popover className='uploaded-file-popover-target'
+                                             popoverClassName='uploaded-file-popover'>
+                                        <span>at row { file.result.errorRowNum }</span>
+                                        <div>
+                                            <h4>Row { file.result.errorRowNum }</h4>
+                                            <p>The content of row { file.result.errorRowNum } is displayed below:</p>
+                                            <pre>{ file.result.errorRowContent }</pre>
+                                        </div>
+                                    </Popover>
+                                }
+                            </p>
+                        </Callout>
+                    }
+                    <div className='uploaded-file-footer-action'>
+                        <Button disabled={ !file.result.success }
+                                intent={ Intent.PRIMARY }
+                                onClick={ onClick }>
+                            Download
+                        </Button>
+                    </div>
+                </Callout>
             </div>
         );
     }

--- a/client/src/saga/county/uploadBallotManifestSaga.ts
+++ b/client/src/saga/county/uploadBallotManifestSaga.ts
@@ -10,15 +10,15 @@ function* importBallotManifestOk(action: any): IterableIterator<any> {
     const { data } = action;
     const { sent } = data;
 
-    notice.ok(`Imported ballot manifest "${sent.filename}".`);
+    notice.ok(`Imported ballot manifest "${sent.fileName}".`);
 }
 
 function* importBallotManifestFail(action: any): IterableIterator<any> {
     const { data } = action;
     const { received, sent } = data;
 
-    switch (sent.hash_status) {
-    case 'MISMATCH': {
+    switch (sent.status) {
+    case 'HASH_MISMATCH': {
         notice.danger('Failed to import ballot manifest.');
         notice.warning('Please verify that the hash matches the file to be uploaded.');
         break;


### PR DESCRIPTION
Implements mockups we had for this widget, with the addition of the row error context displayed in a popover to avoid cluttering the page with potentially long rows.

Resolves [#166043306](https://www.pivotaltracker.com/story/show/166043306).