### PR TITLE
Rename `select` to `mapStateToProps`

### DIFF
--- a/client/src/component/County/Audit/EndOfRound/FinalReviewPageContainer.tsx
+++ b/client/src/component/County/Audit/EndOfRound/FinalReviewPageContainer.tsx
@@ -13,7 +13,7 @@ const Container = (props: Props) => {
     return <FinalReviewPage { ...props } />;
 };
 
-const select = (state: County.AppState) => {
+const mapStateToProps = (state: County.AppState) => {
     return {
         auditBoardIndex: state.auditBoardIndex || 0,
         ballotSequenceAssignment: state.ballotSequenceAssignment,
@@ -21,4 +21,4 @@ const select = (state: County.AppState) => {
     };
 };
 
-export default connect(select)(Container);
+export default connect(mapStateToProps)(Container);

--- a/client/src/component/County/Audit/EndOfRound/PageContainer.tsx
+++ b/client/src/component/County/Audit/EndOfRound/PageContainer.tsx
@@ -25,7 +25,7 @@ class EndOfRoundPageContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(countyState: County.AppState) {
+function mapStateToProps(countyState: County.AppState) {
     const auditBoardIndex = countyState.auditBoardIndex || 0;
     const previousRound = previousRoundSelector(countyState);
 
@@ -41,4 +41,4 @@ function select(countyState: County.AppState) {
     };
 }
 
-export default connect(select)(EndOfRoundPageContainer);
+export default connect(mapStateToProps)(EndOfRoundPageContainer);

--- a/client/src/component/County/Audit/EndOfRound/SignOffFormContainer.tsx
+++ b/client/src/component/County/Audit/EndOfRound/SignOffFormContainer.tsx
@@ -82,10 +82,10 @@ class SignOffFormContainer extends React.Component<ContainerProps, ContainerStat
     }
 }
 
-function select(countyState: County.AppState) {
+function mapStateToProps(countyState: County.AppState) {
     return {
         countyInfo: countyInfo(countyState),
     };
 }
 
-export default connect(select)(SignOffFormContainer);
+export default connect(mapStateToProps)(SignOffFormContainer);

--- a/client/src/component/County/Audit/PageContainer.tsx
+++ b/client/src/component/County/Audit/PageContainer.tsx
@@ -81,7 +81,7 @@ const CountyAuditPageContainer = (props: CountyAuditPageContainerProps) => {
     return <CountyAuditPage reviewingBallotId={ reviewingBallotId } />;
 };
 
-function select(countyState: County.AppState) {
+function mapStateToProps(countyState: County.AppState) {
     const auditBoardIndex = countyState.auditBoardIndex || 0;
     const isAuditBoardDone = isAuditBoardDoneSelector(countyState);
     const finalReviewComplete = countyState.finalReview.complete;
@@ -111,5 +111,5 @@ export default withPoll(
     withCountyState(CountyAuditPageContainer),
     'COUNTY_AUDIT_POLL_START',
     'COUNTY_AUDIT_POLL_STOP',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/County/Audit/Wizard/BallotAuditStageContainer.tsx
+++ b/client/src/component/County/Audit/Wizard/BallotAuditStageContainer.tsx
@@ -26,7 +26,7 @@ type Props = StateProps & OwnProps;
 
 const Component = (props: Props) => <BallotAuditStage { ...props } />;
 
-const select = (countyState: County.AppState): StateProps => {
+const mapStateToProps = (countyState: County.AppState): StateProps => {
     const { currentBallot } = countyState;
 
     const comment = countyState.finalReview.comment;
@@ -43,4 +43,4 @@ const select = (countyState: County.AppState): StateProps => {
     };
 };
 
-export default connect(select)(Component);
+export default connect(mapStateToProps)(Component);

--- a/client/src/component/County/Audit/Wizard/BallotListStageContainer.tsx
+++ b/client/src/component/County/Audit/Wizard/BallotListStageContainer.tsx
@@ -26,7 +26,7 @@ class BallotListStageContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(countyState: County.AppState) {
+function mapStateToProps(countyState: County.AppState) {
     return {
         auditBoardIndex: countyState.auditBoardIndex,
         countyInfo: countyInfo(countyState),
@@ -35,4 +35,4 @@ function select(countyState: County.AppState) {
     };
 }
 
-export default connect(select)(BallotListStageContainer);
+export default connect(mapStateToProps)(BallotListStageContainer);

--- a/client/src/component/County/Audit/Wizard/Container.tsx
+++ b/client/src/component/County/Audit/Wizard/Container.tsx
@@ -23,7 +23,7 @@ const WizardContainer = (props: WizardContainerProps) => {
     return <Wizard { ...props } />;
 };
 
-function select(state: County.AppState, props: WizardContainerOwnProps) {
+function mapStateToProps(state: County.AppState, props: WizardContainerOwnProps) {
     return {
         countyState: state,
         currentBallotNumber: currentBallotNumber(state),
@@ -32,4 +32,4 @@ function select(state: County.AppState, props: WizardContainerOwnProps) {
     };
 }
 
-export default connect(select)(WizardContainer);
+export default connect(mapStateToProps)(WizardContainer);

--- a/client/src/component/County/Audit/Wizard/ReviewStageContainer.tsx
+++ b/client/src/component/County/Audit/Wizard/ReviewStageContainer.tsx
@@ -59,7 +59,7 @@ const ReviewStageContainer = (props: Props) => {
                         uploadAcvr={ uploadAcvr } />;
 };
 
-function select(countyState: County.AppState): StateProps {
+function mapStateToProps(countyState: County.AppState): StateProps {
     const { currentBallot } = countyState;
 
     const auditBoardIndex = countyState.auditBoardIndex || 0;
@@ -75,4 +75,4 @@ function select(countyState: County.AppState): StateProps {
     };
 }
 
-export default connect(select)(ReviewStageContainer);
+export default connect(mapStateToProps)(ReviewStageContainer);

--- a/client/src/component/County/AuditBoard/PageContainer.tsx
+++ b/client/src/component/County/AuditBoard/PageContainer.tsx
@@ -68,7 +68,7 @@ interface SelectProps {
     hasAuditedAnyBallot: boolean;
 }
 
-function select(countyState: County.AppState): SelectProps {
+function mapStateToProps(countyState: County.AppState): SelectProps {
     const countyInfo = countyInfoSelector(countyState);
     const countyName = _.get(countyInfo, 'name', '');
 
@@ -83,5 +83,5 @@ function select(countyState: County.AppState): SelectProps {
 export default withState('County', withSync(
     AuditBoardSignInContainer,
     'COUNTY_BOARD_SIGN_IN_SYNC',
-    select,
+    mapStateToProps,
 ));

--- a/client/src/component/County/Dashboard/BallotManifest/FormContainer.tsx
+++ b/client/src/component/County/Dashboard/BallotManifest/FormContainer.tsx
@@ -162,7 +162,7 @@ class BallotManifestFormContainer extends React.Component<ContainerProps, Contai
     }
 }
 
-const select = (countyState: County.AppState) => {
+const mapStateToProps = (countyState: County.AppState) => {
     const uploadingFile = !!countyState.uploadingBallotManifest;
 
     return {
@@ -172,4 +172,4 @@ const select = (countyState: County.AppState) => {
     };
 };
 
-export default connect(select)(BallotManifestFormContainer);
+export default connect(mapStateToProps)(BallotManifestFormContainer);

--- a/client/src/component/County/Dashboard/CVRExport/FormContainer.tsx
+++ b/client/src/component/County/Dashboard/CVRExport/FormContainer.tsx
@@ -164,7 +164,7 @@ class CVRExportFormContainer extends React.Component<ContainerProps, ContainerSt
     }
 }
 
-const select = (countyState: County.AppState) => {
+const mapStateToProps = (countyState: County.AppState) => {
     const uploadingFile = cvrExportUploadingSelector(countyState);
 
     return {
@@ -174,4 +174,4 @@ const select = (countyState: County.AppState) => {
     };
 };
 
-export default connect(select)(CVRExportFormContainer);
+export default connect(mapStateToProps)(CVRExportFormContainer);

--- a/client/src/component/County/Dashboard/FileUploadContainer.tsx
+++ b/client/src/component/County/Dashboard/FileUploadContainer.tsx
@@ -51,7 +51,7 @@ class FileUploadContainer extends React.Component<FileUploadContainerProps> {
     }
 }
 
-function select(countyState: County.AppState) {
+function mapStateToProps(countyState: County.AppState) {
     const { asm } = countyState;
 
     const missedDeadline = asm.county === 'DEADLINE_MISSED';
@@ -59,4 +59,4 @@ function select(countyState: County.AppState) {
     return { countyState, missedDeadline };
 }
 
-export default connect(select)(FileUploadContainer);
+export default connect(mapStateToProps)(FileUploadContainer);

--- a/client/src/component/County/Dashboard/PageContainer.tsx
+++ b/client/src/component/County/Dashboard/PageContainer.tsx
@@ -85,7 +85,7 @@ class CountyDashboardContainer extends React.Component<DashboardProps> {
     }
 }
 
-function select(countyState: County.AppState) {
+function mapStateToProps(countyState: County.AppState) {
     return {
         allRoundsComplete: allRoundsCompleteSelector(countyState),
         auditComplete: auditCompleteSelector(countyState),
@@ -103,5 +103,5 @@ export default withPoll(
     withCountyState(CountyDashboardContainer),
     'COUNTY_DASHBOARD_POLL_START',
     'COUNTY_DASHBOARD_POLL_STOP',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/DOS/Contest/OverviewPageContainer.tsx
+++ b/client/src/component/DOS/Contest/OverviewPageContainer.tsx
@@ -3,7 +3,7 @@ import withSync from 'corla/component/withSync';
 
 import OverviewPage from './OverviewPage';
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     return {
         contests: dosState.contests,
         dosState,
@@ -13,5 +13,5 @@ function select(dosState: DOS.AppState) {
 export default withSync(
     withDOSState(OverviewPage),
     'DOS_CONTEST_OVERVIEW_SYNC',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/DOS/County/DetailPageContainer.tsx
+++ b/client/src/component/DOS/County/DetailPageContainer.tsx
@@ -34,7 +34,7 @@ class CountyDetailContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     const { countyStatus } = dosState;
 
     return { countyStatus };
@@ -43,5 +43,5 @@ function select(dosState: DOS.AppState) {
 export default withSync(
     withDOSState(CountyDetailContainer),
     'DOS_COUNTY_DETAIL_SYNC',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/DOS/County/OverviewPageContainer.tsx
+++ b/client/src/component/DOS/County/OverviewPageContainer.tsx
@@ -3,7 +3,7 @@ import withSync from 'corla/component/withSync';
 
 import CountyOverviewPage from './OverviewPage';
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     const { countyStatus } = dosState;
 
     return { countyStatus, dosState };
@@ -12,5 +12,5 @@ function select(dosState: DOS.AppState) {
 export default withSync(
     withDOSState(CountyOverviewPage),
     'DOS_COUNTY_OVERVIEW_SYNC',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/DOS/Dashboard/MainContainer.tsx
+++ b/client/src/component/DOS/Dashboard/MainContainer.tsx
@@ -18,7 +18,7 @@ class MainContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     return {
         auditDefined: auditStarted(dosState),
         canRenderReport: canRenderReport(dosState),
@@ -26,4 +26,4 @@ function select(dosState: DOS.AppState) {
     };
 }
 
-export default connect(select)(MainContainer);
+export default connect(mapStateToProps)(MainContainer);

--- a/client/src/component/DOS/Dashboard/PageContainer.tsx
+++ b/client/src/component/DOS/Dashboard/PageContainer.tsx
@@ -25,7 +25,7 @@ class DOSDashboardContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     return {
         auditStarted: auditStartedSelector(dosState),
         contests: dosState.contests,
@@ -39,5 +39,5 @@ export default withPoll(
     withDOSState(DOSDashboardContainer),
     'DOS_DASHBOARD_POLL_START',
     'DOS_DASHBOARD_POLL_STOP',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/DOS/Dashboard/RoundContainer.tsx
+++ b/client/src/component/DOS/Dashboard/RoundContainer.tsx
@@ -40,7 +40,7 @@ class RoundContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     const currentRound = currentRoundSelector(dosState);
     const countiesWithRound = countiesWithRoundSelector(dosState, currentRound);
 
@@ -63,4 +63,4 @@ function select(dosState: DOS.AppState) {
     };
 }
 
-export default connect(select)(RoundContainer);
+export default connect(mapStateToProps)(RoundContainer);

--- a/client/src/component/DOS/DefineAudit/ReviewPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/ReviewPageContainer.tsx
@@ -42,12 +42,12 @@ class ReviewPageContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     return { dosState };
 }
 
 export default withSync(
     withDOSState(ReviewPageContainer),
     'DOS_DEFINE_AUDIT_REVIEW_SYNC',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/DOS/DefineAudit/SeedPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/SeedPageContainer.tsx
@@ -46,7 +46,7 @@ class SeedPageContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     if (!dosState) { return {}; }
 
     return {
@@ -59,5 +59,5 @@ function select(dosState: DOS.AppState) {
 export default withSync(
     withDOSState(SeedPageContainer),
     'DOS_DEFINE_AUDIT_RANDOM_SEED_SYNC',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/DOS/DefineAudit/SelectContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/SelectContestsPageContainer.tsx
@@ -53,7 +53,7 @@ class SelectContestsPageContainer extends React.Component<ContainerProps> {
     }
 }
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     const isAuditable = (contestId: number): boolean => {
         if (!dosState.auditTypes) { return false; }
 
@@ -74,5 +74,5 @@ export default withPoll(
     withDOSState(SelectContestsPageContainer),
     'DOS_SELECT_CONTESTS_POLL_START',
     'DOS_SELECT_CONTESTS_POLL_STOP',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/DOS/DefineAudit/StartPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StartPageContainer.tsx
@@ -126,7 +126,7 @@ class StartPageContainer extends React.Component<ContainerProps, ContainerState>
     }
 }
 
-function select(dosState: DOS.AppState) {
+function mapStateToProps(dosState: DOS.AppState) {
     const { election, publicMeetingDate, riskLimit } = dosState;
 
     return { election, riskLimit, publicMeetingDate, dosState };
@@ -135,5 +135,5 @@ function select(dosState: DOS.AppState) {
 export default withSync(
     withDOSState(StartPageContainer),
     'DOS_DEFINE_AUDIT_SYNC',
-    select,
+    mapStateToProps,
 );

--- a/client/src/component/Login/Container.tsx
+++ b/client/src/component/Login/Container.tsx
@@ -35,8 +35,8 @@ export class LoginContainer extends React.Component<LoginProps> {
     }
 }
 
-function select(state: AppState) {
+function mapStateToProps(state: AppState) {
     return { stateType: state.type };
 }
 
-export default connect(select)(LoginContainer);
+export default connect(mapStateToProps)(LoginContainer);

--- a/client/src/component/RootRedirectContainer.tsx
+++ b/client/src/component/RootRedirectContainer.tsx
@@ -33,8 +33,8 @@ export class RootRedirectContainer extends React.Component<RootRedirectContainer
     }
 }
 
-function select(state: AppState) {
+function mapStateToProps(state: AppState) {
     return { stateType: state.type };
 }
 
-export default connect(select)(RootRedirectContainer);
+export default connect(mapStateToProps)(RootRedirectContainer);

--- a/client/src/component/withPoll.tsx
+++ b/client/src/component/withPoll.tsx
@@ -8,7 +8,7 @@ function withSync<P, SelectP, TOwnProps, TState, BindP, BindS>(
     Wrapped: React.ComponentType<P>,
     didMount: string,
     willUnmount: string,
-    select: MapStateToProps<SelectP, TOwnProps, TState>,
+    mapStateToProps: MapStateToProps<SelectP, TOwnProps, TState>,
     bind?: Bind<BindP, BindS>,
 ) {
     type WrapperProps = P & SelectP & TOwnProps & BindP;
@@ -28,9 +28,9 @@ function withSync<P, SelectP, TOwnProps, TState, BindP, BindS>(
     }
 
     if (bind) {
-        return connect(select, bind)(Wrapper);
+        return connect(mapStateToProps, bind)(Wrapper);
     } else {
-        return connect(select)(Wrapper);
+        return connect(mapStateToProps)(Wrapper);
     }
 }
 

--- a/client/src/component/withState.tsx
+++ b/client/src/component/withState.tsx
@@ -23,13 +23,13 @@ function withState<P>(
         }
     }
 
-    function select(state: AppState) {
+    function mapStateToProps(state: AppState) {
         const hasState = state.type === stateType;
 
         return { hasState };
     }
 
-    return connect(select)(Wrapper);
+    return connect(mapStateToProps)(Wrapper);
 }
 
 export default withState;

--- a/client/src/component/withSync.tsx
+++ b/client/src/component/withSync.tsx
@@ -7,7 +7,7 @@ import action from 'corla/action';
 function withSync<P, SelectP, TOwnProps, TState, BindP, BindS>(
     Wrapped: React.ComponentType<P>,
     didMount: string,
-    select: MapStateToProps<SelectP, TOwnProps, TState>,
+    mapStateToProps: MapStateToProps<SelectP, TOwnProps, TState>,
     bind?: Bind<BindP, BindS>,
 ) {
     type Props = P & SelectP & TOwnProps & BindP;
@@ -23,9 +23,9 @@ function withSync<P, SelectP, TOwnProps, TState, BindP, BindS>(
     }
 
     if (bind) {
-        return connect(select, bind)(Wrapper);
+        return connect(mapStateToProps, bind)(Wrapper);
     } else {
-        return connect(select)(Wrapper);
+        return connect(mapStateToProps)(Wrapper);
     }
 }
 


### PR DESCRIPTION
This matches the react-redux `connect` [documentation][1], and so makes the code easier to understand for newcomers.

[1]: https://react-redux.js.org/using-react-redux/connect-mapstate