### PR TITLE
Fix infinite round loop under certain circumstances

### DIFF
--- a/client/src/action/county/downloadCvrsToAuditCsv.ts
+++ b/client/src/action/county/downloadCvrsToAuditCsv.ts
@@ -1,7 +1,7 @@
 import { endpoint } from 'corla/config';
 
 export default (round: number) => {
-    const params = `round=${round}&include_audited`;
+    const params = `round=${round}`;
     const url = `${endpoint('cvr-to-audit-download')}?${params}`;
 
     window.location.replace(url);

--- a/client/src/action/county/fetchCvrsToAudit.ts
+++ b/client/src/action/county/fetchCvrsToAudit.ts
@@ -3,7 +3,7 @@ import { endpoint } from 'corla/config';
 import createFetchAction from 'corla/action/createFetchAction';
 
 export default (round: number) => {
-    const params = `round=${round}&include_audited`;
+    const params = `round=${round}`;
     const url = `${endpoint('cvr-to-audit-list')}?${params}`;
 
     const a = createFetchAction({

--- a/client/src/component/County/Audit/EndOfRound/FinalReviewPage.tsx
+++ b/client/src/component/County/Audit/EndOfRound/FinalReviewPage.tsx
@@ -138,13 +138,14 @@ class FinalReviewPage extends React.Component<FinalReviewPageProps, FinalReviewP
                         </tr>
                     </thead>
                     <tbody>
-                    {
-                        _.map(auditBoardSlice(
-                            cvrsToAudit,
-                            ballotSequenceAssignment,
-                            auditBoardIndex,
-                        ), renderRow)
-                    }
+                    { _.chain(auditBoardSlice(
+                           cvrsToAudit,
+                           ballotSequenceAssignment,
+                           auditBoardIndex,
+                       ))
+                       .filter(cvr => !cvr.previously_audited)
+                       .map(renderRow)
+                       .value() }
                     </tbody>
                 </table>
             </Card>;

--- a/client/src/types/json.d.ts
+++ b/client/src/types/json.d.ts
@@ -107,6 +107,7 @@ declare namespace JSON {
         db_id?: number;
         id: number;
         imprinted_id: string;
+        previously_audited?: boolean;
         record_id: number;
         record_type: RecordType;
         scanner_id: number;

--- a/server/eclipse-project/script/rla_export/rla_export/__main__.py
+++ b/server/eclipse-project/script/rla_export/rla_export/__main__.py
@@ -696,7 +696,7 @@ def pull_endpoints(args, ac):
                     # This query doesn't work in 2.0.11, so leave it out by default and avoid confusion
                     filename = os.path.join(args.export_dir, 'ballot_list_%s.csv' % county_name)
                     query = ("cvr-to-audit-download?county=%d&start=0&ballot_count=%d"
-                            "&include_audited" % (county_id, ballot_count))
+                             (county_id, ballot_count))
                     r = download_content(session, baseurl, query, filename)
 
                 filename = os.path.join(args.export_dir, 'county_report_%s.xlsx' % county_name)

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/BallotSelection.java
@@ -519,7 +519,8 @@ public final class BallotSelection {
                                   cvr.id(),
                                   cvr.ballotType(),
                                   storageLocation,
-                                  cvr.auditFlag());
+                                  cvr.auditFlag(),
+                                  cvr.previouslyAudited());
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -118,55 +117,36 @@ public final class ComparisonAuditController {
    *         any ballot cards, for instance when the round number is invalid,
    *         the returned list is empty.
    */
+  // TODO: includeAudited is unused
   public static List<CastVoteRecord>
       ballotsToAudit(final CountyDashboard countyDashboard,
                      final int roundNumber,
-                     final boolean audited) {
-
-    final List<Long> cvrIds = cvrIdsToAudit(countyDashboard, roundNumber);
-
-    LOGGER.debug(String.format("Ballot cards to audit: "
-                               + "[round=%d, n = %d,"
-                               + " cvrIds = %s]",
-                               roundNumber, cvrIds.size(),
-                               cvrIds));
-
-    final List<CastVoteRecord> cvrs = CastVoteRecordQueries.get(cvrIds);
-
-    return cvrs.stream()
-      .map(c -> {c.setAuditFlag(audited(countyDashboard, c)); return c;})
-      // remove if audited is false and auditFlag is true
-      .filter(c -> audited || !c.auditFlag())
-      .collect(Collectors.toList());
-  }
-
-  /**
-   * access the list of cvrIds stored on the round, and subtract those from previous
-   * rounds
-   **/
-  public static List<Long> cvrIdsToAudit(final CountyDashboard countyDashboard,
-                                         final int roundNumber) {
+                     final boolean includeAudited) {
     final Round round;
-    final List<Round> rounds;
 
     try {
       // roundNumber is 1-based
       round = countyDashboard.rounds().get(roundNumber - 1);
-      rounds = countyDashboard.rounds();
     } catch (IndexOutOfBoundsException e) {
-      return new ArrayList<Long>();
+      return new ArrayList<CastVoteRecord>();
     }
 
-    // we can't filter on "auditFlag" because we need to fetch these for the
-    // final review page.
-    final Set<Long> previouslyAudited = rounds.stream()
-      .filter(r -> r.number() < roundNumber)
-      .map(r -> r.ballotSequence())
-      .flatMap(List::stream)
-      .collect(Collectors.toSet());
-    return round.ballotSequence().stream()
-      .filter(cvrId -> !previouslyAudited.contains(cvrId))
-      .collect(Collectors.toList());
+    LOGGER.info(String.format("Ballot cards to audit: "
+                              + "[round=%s, round.ballotSequence.size() = %d,"
+                              + " round.ballotSequence() = %s]",
+                              round, round.ballotSequence().size(),
+                              round.ballotSequence()));
+
+    // we already have the list of CVR IDs for the round
+    final List<CastVoteRecord> cvrs = CastVoteRecordQueries.get(round.ballotSequence());
+
+    // PERF: Is this a hotspot? We can figure out the audit flag using a single
+    // query.
+    for (final CastVoteRecord cvr : cvrs) {
+      cvr.setAuditFlag(audited(countyDashboard, cvr));
+    }
+
+    return cvrs;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
@@ -66,11 +66,6 @@ public class CVRToAuditDownload extends AbstractEndpoint {
   public static final String BALLOT_COUNT = "ballot_count";
 
   /**
-   * The "include audited" parameter.
-   */
-  public static final String INCLUDE_AUDITED = "include_audited";
-
-  /**
    * The "round" parameter.
    */
   public static final String ROUND = "round";
@@ -181,7 +176,6 @@ public class CVRToAuditDownload extends AbstractEndpoint {
       // get the request parameters
       final String start_param = the_request.queryParams(START);
       final String ballot_count_param = the_request.queryParams(BALLOT_COUNT);
-      final String audited_param = the_request.queryParams(INCLUDE_AUDITED);
       final String round_param = the_request.queryParams(ROUND);
 
       int ballot_count = 0;
@@ -194,12 +188,6 @@ public class CVRToAuditDownload extends AbstractEndpoint {
         index = Integer.parseInt(start_param);
       }
 
-      final boolean audited;
-      if (audited_param == null) {
-        audited = false;
-      } else {
-        audited = true;
-      }
       // get other things we need
       final CountyDashboard cdb = Persistence.getByID(county.id(), CountyDashboard.class);
       final List<CastVoteRecord> cvr_to_audit_list;
@@ -218,11 +206,13 @@ public class CVRToAuditDownload extends AbstractEndpoint {
       }
 
       if (round.isPresent()) {
-        cvr_to_audit_list =
-            ComparisonAuditController.ballotsToAudit(cdb, round.getAsInt(), audited);
+        cvr_to_audit_list = ComparisonAuditController.ballotsToAudit(
+            cdb,
+            round.getAsInt()
+        );
+        response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
+        response_list.sort(null);
 
-      response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
-      response_list.sort(null);
         final Round roundObject = cdb.rounds().get(round.getAsInt() - 1);
 
         final List<Map<String, Integer>> bsa =
@@ -232,6 +222,10 @@ public class CVRToAuditDownload extends AbstractEndpoint {
           // Walk the sequence assignments getting the audit boards' index and
           // count values. Use that information to set the audit board index for
           // each response row.
+          //
+          // Note: the board assignment has already been created, so the list of
+          // ballots returned to the client cannot change after the round
+          // starts.
           for (int i = 0; i < bsa.size(); i++) {
             final Map<String, Integer> m = bsa.get(i);
 
@@ -239,7 +233,6 @@ public class CVRToAuditDownload extends AbstractEndpoint {
             final Integer boardCount = m.get("count");
 
             for (int j = boardIndex; j < boardIndex + boardCount; j++) {
-              // TODO: Will this always agree with the round information?
               final CVRToAuditResponse row = response_list.get(j);
               row.setAuditBoardIndex(i);
             }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditDownload.java
@@ -221,16 +221,14 @@ public class CVRToAuditDownload extends AbstractEndpoint {
         cvr_to_audit_list =
             ComparisonAuditController.ballotsToAudit(cdb, round.getAsInt(), audited);
 
-        response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
-        response_list.sort(null);
+      response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
+      response_list.sort(null);
         final Round roundObject = cdb.rounds().get(round.getAsInt() - 1);
 
         final List<Map<String, Integer>> bsa =
           roundObject.ballotSequenceAssignment();
 
-        // The ballot sequence assignments won't line up if audited cvrs are filtered out.
-        // The audited param is never false and should probably be removed.
-        if (bsa != null && audited) {
+        if (bsa != null) {
           // Walk the sequence assignments getting the audit boards' index and
           // count values. Use that information to set the audit board index for
           // each response row.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -46,16 +46,6 @@ public class CVRToAuditList extends AbstractEndpoint {
   public static final String START = "start";
 
   /**
-   * The "include duplicates" parameter.
-   */
-  public static final String INCLUDE_DUPLICATES = "include_duplicates";
-
-  /**
-   * The "include audited" parameter.
-   */
-  public static final String INCLUDE_AUDITED = "include_audited";
-
-  /**
    * The "round" parameter.
    */
   public static final String ROUND = "round";
@@ -150,16 +140,9 @@ public class CVRToAuditList extends AbstractEndpoint {
     }
 
     try {
-      // get the request parameters
-      final String audited_param = the_request.queryParams(INCLUDE_AUDITED);
+      // get the request parameter
       final String round_param = the_request.queryParams(ROUND);
 
-      final boolean audited;
-      if (audited_param == null) {
-        audited = false;
-      } else {
-        audited = true;
-      }
       // get other things we need
       final CountyDashboard cdb = Persistence.getByID(county.id(), CountyDashboard.class);
       final List<CastVoteRecord> cvr_to_audit_list;
@@ -178,8 +161,10 @@ public class CVRToAuditList extends AbstractEndpoint {
       }
 
       if (round.isPresent()) {
-        cvr_to_audit_list =
-            ComparisonAuditController.ballotsToAudit(cdb, round.getAsInt(), audited);
+        cvr_to_audit_list = ComparisonAuditController.ballotsToAudit(
+            cdb,
+            round.getAsInt()
+        );
         response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
         response_list.sort(null);
 
@@ -192,6 +177,10 @@ public class CVRToAuditList extends AbstractEndpoint {
           // Walk the sequence assignments getting the audit boards' index and
           // count values. Use that information to set the audit board index for
           // each response row.
+          //
+          // Note: the board assignment has already been created, so the list of
+          // ballots returned to the client cannot change after the round
+          // starts.
           for (int i = 0; i < bsa.size(); i++) {
             final Map<String, Integer> m = bsa.get(i);
 
@@ -199,7 +188,6 @@ public class CVRToAuditList extends AbstractEndpoint {
             final Integer boardCount = m.get("count");
 
             for (int j = boardIndex; j < boardIndex + boardCount; j++) {
-              // TODO: Will this always agree with the round information?
               final CVRToAuditResponse row = response_list.get(j);
               row.setAuditBoardIndex(i);
             }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/CVRToAuditList.java
@@ -179,7 +179,7 @@ public class CVRToAuditList extends AbstractEndpoint {
 
       if (round.isPresent()) {
         cvr_to_audit_list =
-          ComparisonAuditController.ballotsToAudit(cdb, round.getAsInt(), audited);
+            ComparisonAuditController.ballotsToAudit(cdb, round.getAsInt(), audited);
         response_list.addAll(BallotSelection.toResponseList(cvr_to_audit_list));
         response_list.sort(null);
 
@@ -188,9 +188,7 @@ public class CVRToAuditList extends AbstractEndpoint {
         final List<Map<String, Integer>> bsa =
           roundObject.ballotSequenceAssignment();
 
-        // The ballot sequence assignments won't line up if audited cvrs are filtered out.
-        // The audited param is never false and should probably be removed.
-        if (bsa != null && audited) {
+        if (bsa != null) {
           // Walk the sequence assignments getting the audit boards' index and
           // count values. Use that information to set the audit board index for
           // each response row.
@@ -202,15 +200,8 @@ public class CVRToAuditList extends AbstractEndpoint {
 
             for (int j = boardIndex; j < boardIndex + boardCount; j++) {
               // TODO: Will this always agree with the round information?
-              try {
-                final CVRToAuditResponse row = response_list.get(j);
-                row.setAuditBoardIndex(i);
-              } catch (final IndexOutOfBoundsException e) {
-                // the ballotsToAudit may or may not equal the total number of
-                // ballots selected for this round because of duplicates. The
-                // ballotSequenceAssignment is set from round.expectedCount and
-                // duplicates are taken out of ballotsToAudit after that is set.
-              }
+              final CVRToAuditResponse row = response_list.get(j);
+              row.setAuditBoardIndex(i);
             }
           }
         }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetAuditBoardCount.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/SetAuditBoardCount.java
@@ -25,7 +25,6 @@ import spark.Request;
 import spark.Response;
 
 import us.freeandfair.corla.Main;
-import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.model.County;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.model.Round;
@@ -101,10 +100,7 @@ public class SetAuditBoardCount extends AbstractCountyDashboardEndpoint {
         badDataContents(response, "round not started");
       }
 
-
-      final Integer ballotCount = ComparisonAuditController
-        .cvrIdsToAudit(countyDashboard, round.number())
-        .size();
+      final Integer ballotCount = round.expectedCount();
 
       if (ballotCount == null) {
         Main.LOGGER.error(String.format(

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRToAuditResponse.java
@@ -82,6 +82,12 @@ public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
   protected final boolean my_audited;
 
   /**
+   * A flag that indicates whether or not the CVR was audited in a previous
+   * round
+   */
+  protected final boolean my_previously_audited;
+
+  /**
    * Create a new response object.
    *
    * @param the_audit_sequence_number The audit sequence number.
@@ -94,6 +100,8 @@ public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
    * @param the_ballot_type The ballot type.
    * @param the_storage_location The storage location.
    * @param the_audited true if the ballot has been audited, false otherwise.
+   * @param the_previously_audited true if the ballot has been audited in a
+   *                               previous round, false otherwise.
    */
   @SuppressWarnings("PMD.ExcessiveParameterList")
   public CVRToAuditResponse(final int the_audit_sequence_number,
@@ -105,7 +113,8 @@ public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
                             final long the_db_id,
                             final String the_ballot_type,
                             final String the_storage_location,
-                            final boolean the_audited) {
+                            final boolean the_audited,
+                            final boolean the_previously_audited) {
     my_audit_sequence_number = the_audit_sequence_number;
     my_scanner_id = the_scanner_id;
     my_batch_id = the_batch_id;
@@ -116,6 +125,7 @@ public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
     my_ballot_type = the_ballot_type;
     my_storage_location = the_storage_location;
     my_audited = the_audited;
+    my_previously_audited = the_previously_audited;
   }
 
   /**
@@ -200,6 +210,13 @@ public class CVRToAuditResponse implements Comparable<CVRToAuditResponse> {
    */
   public boolean audited() {
     return my_audited;
+  }
+
+  /**
+   * @return the "previously audited" flag.
+   */
+  public boolean previouslyAudited() {
+    return my_previously_audited;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CastVoteRecord.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CastVoteRecord.java
@@ -208,6 +208,12 @@ final public class CastVoteRecord implements Comparable<CastVoteRecord>,
    */
   private transient boolean my_audit_flag;
 
+  /**
+   * A transient flag that indicates whether this CVR was audited in a "previous
+   * round"; this is only used for passing information around and is not
+   * serialized in the database.
+   */
+  private transient boolean my_previously_audited;
 
   /**
    * The CVR to audit, for ACVRs only
@@ -564,6 +570,23 @@ final public class CastVoteRecord implements Comparable<CastVoteRecord>,
    */
   public void setAuditFlag(final boolean the_audit_flag) {
     my_audit_flag = the_audit_flag;
+  }
+
+  /**
+   * Whether or not the ballot was previously audited
+   *
+   * Like auditFlag(), this is not persisted to the database, and is only used
+   * during a single run of the tool.
+   */
+  public boolean previouslyAudited() {
+    return my_previously_audited;
+  }
+
+  /**
+   * Set whether or not the ballot was previously audited
+   */
+  public void setPreviouslyAudited(final boolean the_previously_audited) {
+    my_previously_audited = the_previously_audited;
   }
 
   /**

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -584,23 +584,8 @@ public class CountyDashboard implements PersistentEntity {
     } else {
 
       final Round round = currentRound();
-      final List<Round> rounds = rounds();
 
-      // the deduplication process, that sets ballotSequence, does not consider
-      // previous rounds, unfortunately.
-      // Since cvrs are not audited twice, those
-      // from previous rounds are not considered "remaining"
-      final Set<Long> previouslyAudited = rounds.stream()
-        .filter(r -> r.number() < round.number())
-        .map(r -> r.ballotSequence())
-        .flatMap(List::stream)
-        .collect(Collectors.toSet());
-      final List<Long> cvrIds = round.ballotSequence().stream()
-        .filter(cvrId -> !previouslyAudited.contains(cvrId))
-        .collect(Collectors.toList());
-
-
-      result = cvrIds.size() - round.actualCount();
+      result = round.ballotSequence().size() - round.actualCount();
 
       LOGGER.debug(String.format("[ballotsRemainingInCurrentRound:"
                                  + " index=%d, result=%d,"


### PR DESCRIPTION
This contains a reversion of PR #138, as well as introducing a new "previously audited" non-persisted CVR flag that the UI can use to filter ballots audited in previous rounds. 

Fixes [#166194453](https://www.pivotaltracker.com/story/show/166194453).