### PR TITLE
[api] remove previouslyAudited cvrs during the selection process

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/StartAuditRound.java
@@ -375,8 +375,14 @@ public class StartAuditRound extends AbstractDoSDashboardEndpoint {
                       cdb,
                       segment.cvrsInBallotSequence()));
 
+          final Set<Long> previouslyAudited = cdb.previouslyAudited();
+
+          final List<CastVoteRecord> uniqueNewCvrs = ballotSequenceCVRs.stream()
+            .filter(cvr -> !previouslyAudited.contains(cvr.id()))
+            .collect(Collectors.toList());
+
           // ballotSequence is *just* the CVR IDs, as expected.
-          final List<Long> ballotSequence = ballotSequenceCVRs.stream()
+          final List<Long> ballotSequence = uniqueNewCvrs.stream()
               .map(cvr -> cvr.id())
               .collect(Collectors.toList());
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/CountyDashboard.java
@@ -515,6 +515,20 @@ public class CountyDashboard implements PersistentEntity {
     }
   }
 
+  /** all the cvr ids that have been selected from previous rounds **/
+  public Set<Long> previouslyAudited() {
+    // this might be better:
+    // return CastVoteRecordQueries.previouslyAudited(this);
+
+    // this one will need to
+    // consider rounds that are in progress because ballotSequence will not
+    // equal the audited ids in that case
+    return rounds().stream()
+      .map(r -> r.ballotSequence())
+      .flatMap(s -> s.stream())
+      .collect(Collectors.toSet());
+  }
+
   /**
    * Begins a new round with the specified number of ballots to audit
    * and expected achieved prefix length, starting at the specified index


### PR DESCRIPTION
This will correct the "remaining in round" number on the dashboard, which can be larger than it should be with multiple rounds and duplicate selections. The number is for display only, not used in calculations.