### PR TITLE
Breadcrumb typo: "County" -> "Counties"

### DIFF
--- a/client/src/component/DOS/County/DetailPage.tsx
+++ b/client/src/component/DOS/County/DetailPage.tsx
@@ -15,7 +15,7 @@ interface BreadcrumbProps {
 const Breadcrumbs = ({ county }: BreadcrumbProps) => (
     <ul className='pt-breadcrumbs'>
         <li><Breadcrumb text='SoS' href='/sos' /></li>
-        <li><Breadcrumb text='County' href='/sos/county' /></li>
+        <li><Breadcrumb text='Counties' href='/sos/county' /></li>
         <li><Breadcrumb className='pt-breadcrumb-current' text={ county.name } /></li>
     </ul>
 );


### PR DESCRIPTION
Resolves [#166312524](https://www.pivotaltracker.com/story/show/166312524).