### PR TITLE
Immediately show deleted files on the DOS dashboard

### DIFF
--- a/client/src/action/county/deleteFile.ts
+++ b/client/src/action/county/deleteFile.ts
@@ -19,20 +19,18 @@ async function deleteFile(fileType: string) {
         const received = await r.json().catch(empty);
 
         if (!r.ok) {
-            action('DELETE_FILE_FAIL', {fileType, received});
+            action('DELETE_FILE_FAIL', { fileType, received });
             return false;
         }
 
-        action('DELETE_FILE_OK', {fileType, received});
+        action('DELETE_FILE_OK', { fileType, received });
         return true;
 
     } catch (e) {
-        action('DELETE_FILE_NETWORK_FAIL', {fileType});
+        action('DELETE_FILE_NETWORK_FAIL', { fileType });
 
         throw e;
-
     }
-
 }
 
 export default deleteFile;

--- a/client/src/action/dos/deleteFileForCounty.ts
+++ b/client/src/action/dos/deleteFileForCounty.ts
@@ -12,27 +12,25 @@ async function deleteFileForCounty(fileType: string, countyId: number) {
     };
 
     try {
-        action('DELETE_FILE_SEND', { fileType, countyId });
+        action('DOS_DELETE_FILE_SEND', { fileType, countyId });
 
         const r = await fetch(deleteFileUrl, init);
 
         const received = await r.json().catch(empty);
 
         if (!r.ok) {
-            action('DELETE_FILE_FAIL', {fileType, received});
+            action('DOS_DELETE_FILE_FAIL', { fileType, received });
             return false;
         }
 
-        action('DELETE_FILE_OK', {fileType, countyId, received});
+        action('DOS_DELETE_FILE_OK', { fileType, countyId, received });
         return true;
 
     } catch (e) {
-        action('DELETE_FILE_NETWORK_FAIL', {fileType, countyId});
+        action('DOS_DELETE_FILE_NETWORK_FAIL', { fileType, countyId });
 
         throw e;
-
     }
-
 }
 
 export default deleteFileForCounty;

--- a/client/src/component/County/Dashboard/CVRExport/FormContainer.tsx
+++ b/client/src/component/County/Dashboard/CVRExport/FormContainer.tsx
@@ -36,7 +36,7 @@ const UploadedCVRExport = (props: UploadedProps) => {
             <div>
                 <div className='mb-default'>
                     <div className='form-container-heading'><strong>CVR Export</strong></div>
-                    <div className='mb-default'><strong>File name: </strong>"{ file.fileName }"</div>
+                    <div><strong>File name: </strong>"{ file.fileName }"</div>
                     <div><strong>SHA-256 hash: </strong>{ file.hash }</div>
                 </div>
                 <div className='error'>

--- a/client/src/component/FileDownloadButtons.tsx
+++ b/client/src/component/FileDownloadButtons.tsx
@@ -22,10 +22,9 @@ class UploadedFileCard extends React.Component<UploadedFileProps, UploadedFileSt
         this.state = { deleting: false };
     }
 
-    public componentDidUpdate(prevProps: UploadedFileProps) {
-        /* the file has been deleted, says the dosDashboardRefresh */
-        if (!!prevProps.file && !this.props.file) {
-            this.setState({deleting: false});
+    public componentDidUpdate() {
+        if (this.state.deleting && !this.props.file) {
+            this.setState({ deleting: false });
         }
     }
 
@@ -42,7 +41,7 @@ class UploadedFileCard extends React.Component<UploadedFileProps, UploadedFileSt
 
             const onClick = () => downloadFile(file.id);
             const onDelete = () => {
-                this.setState({deleting: true});
+                this.setState({ deleting: true });
                 deleteFileForCounty(fileType, file.countyId);
             };
 

--- a/client/src/reducer/dos/deleteFileOk.ts
+++ b/client/src/reducer/dos/deleteFileOk.ts
@@ -1,0 +1,28 @@
+import * as _ from 'lodash';
+
+export default function deleteFileOk(
+    state: DOS.AppState,
+    action: Action.DOSDeleteFileOk,
+): DOS.AppState {
+    const nextState = state;
+
+    if (!action.data.countyId) {
+        return nextState;
+    }
+
+    const countyId = action.data.countyId;
+
+    switch (action.data.fileType) {
+        case 'bmi': {
+            delete nextState.countyStatus[countyId].ballotManifest;
+            return _.cloneDeep(nextState);
+        }
+        case 'cvr': {
+            delete nextState.countyStatus[countyId].cvrExport;
+            return _.cloneDeep(nextState);
+        }
+        default: {
+            return nextState;
+        }
+    }
+}

--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -1,5 +1,5 @@
 import countyDashboardRefreshOk from './county/dashboardRefreshOk';
-import deleteFileOK from './county/deleteFileOK';
+import countyDeleteFileOk from './county/deleteFileOK';
 import fetchAuditBoardASMStateOk from './county/fetchAuditBoardASMStateOk';
 import countyFetchContestsOk from './county/fetchContestsOk';
 import fetchCountyASMStateOk from './county/fetchCountyASMStateOk';
@@ -16,6 +16,7 @@ import uploadingCvrExport from './county/uploadingCvrExport';
 
 import dosContestFetchOk from './dos/contestFetchOk';
 import dosDashboardRefreshOk from './dos/dashboardRefreshOk';
+import dosDeleteFileOk from './dos/deleteFileOk';
 import fetchDOSASMStateOk from './dos/fetchDOSASMStateOk';
 import dosLoginOk from './dos/loginOk';
 import uploadRandomSeedOk from './dos/uploadRandomSeedOk';
@@ -89,7 +90,11 @@ export default function root(state: AppState, action: Action.App) {
     }
 
     case 'DELETE_FILE_OK': {
-        return deleteFileOK(state as County.AppState, action);
+        return countyDeleteFileOk(state as County.AppState, action);
+    }
+
+    case 'DOS_DELETE_FILE_OK': {
+        return dosDeleteFileOk(state as DOS.AppState, action);
     }
 
     case 'IMPORT_CVR_EXPORT_OK': {

--- a/client/src/types/action.d.ts
+++ b/client/src/types/action.d.ts
@@ -16,6 +16,7 @@ declare namespace Action {
         | CountyFetchCvrOk
         | CountyLoginOk
         | DOSDashboardRefreshOk
+        | DOSDeleteFileOk
         | DOSFetchContestsOk
         | DOSLoginOk
         | DeleteFileOK
@@ -92,6 +93,11 @@ declare namespace Action {
 
     interface DOSDashboardRefreshOk {
         type: 'DOS_DASHBOARD_REFRESH_OK';
+        data: any;
+    }
+
+    interface DOSDeleteFileOk {
+        type: 'DOS_DELETE_FILE_OK';
         data: any;
     }
 


### PR DESCRIPTION
Resolves an issue Monica reported where a full refresh was required to see deleted files, giving the impression that the application had failed in production when the timeouts are longer.