### PR TITLE
Affirmation text on the county report has more room

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/CountyReport.java
@@ -800,13 +800,13 @@ public class CountyReport {
     row.setHeightInPoints(affirmationRowHeight * 2);
     CellUtil.createCell(row, cell_number++, AFFIRMATION_STATEMENT, wrapped_style);
 
-    // Merge the affirmation row columns 0-2
+    // Merge the affirmation row columns A-G (0-6)
     affirmation_sheet.addMergedRegion(
         new CellRangeAddress(
             row_number - 1,
             row_number - 1,
             0,
-            2
+            6
         )
     );
 


### PR DESCRIPTION
Using cells A-G instead of A-C to give it some room to breathe.