### PR TITLE
Remove spinners on CVR upload error

### DIFF
--- a/client/src/component/County/Dashboard/BallotManifest/FormContainer.tsx
+++ b/client/src/component/County/Dashboard/BallotManifest/FormContainer.tsx
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import * as React from 'react';
 import { connect } from 'react-redux';
 
@@ -94,7 +95,8 @@ class BallotManifestFormContainer extends React.Component<ContainerProps, Contai
     }
 
     public componentDidUpdate(prevProps: ContainerProps) {
-        if (prevProps.uploadingFile !== this.props.uploadingFile) {
+        // Remove temporary state override if anything at all changed
+        if (!_.isEqual(prevProps, this.props)) {
             this.setState({ uploadClicked: false });
         }
     }

--- a/client/src/component/County/Dashboard/CVRExport/FormContainer.tsx
+++ b/client/src/component/County/Dashboard/CVRExport/FormContainer.tsx
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import * as React from 'react';
 import { connect } from 'react-redux';
 
@@ -96,7 +97,8 @@ class CVRExportFormContainer extends React.Component<ContainerProps, ContainerSt
     }
 
     public componentDidUpdate(prevProps: ContainerProps) {
-        if (prevProps.uploadingFile !== this.props.uploadingFile) {
+        // Remove temporary state override if anything at all changed
+        if (!_.isEqual(prevProps, this.props)) {
             this.setState({ uploadClicked: false });
         }
     }


### PR DESCRIPTION
This now waits until a deep equality comparison on the props changes, ensuring that any prop change will remove the temporary spinner state.

Resolves [#166389664](https://www.pivotaltracker.com/story/show/166389664)