### PR TITLE
Update DoS dashboard to handle multiple audit boards

### DIFF
--- a/client/src/adapter/dosDashboardRefresh.ts
+++ b/client/src/adapter/dosDashboardRefresh.ts
@@ -64,9 +64,9 @@ function parseCountyStatus(countyStatus: any) {
     _.forEach(countyStatus, c => {
         result[c.id] = {
             asmState: c.asm_state,
-            auditBoard: parseAuditBoard(c.audit_board),
             auditBoardASMState: c.audit_board_asm_state,
             auditBoardCount: c.audit_board_count,
+            auditBoards: _.map(c.audit_boards, parseAuditBoard),
             auditedBallotCount: c.audited_ballot_count,
             ballotManifest: parseFile(c.ballot_manifest_file),
             ballotsRemainingInRound: c.ballots_remaining_in_round,

--- a/client/src/component/DOS/County/DetailPage.tsx
+++ b/client/src/component/DOS/County/DetailPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import * as _ from 'lodash';
 
-import { Breadcrumb } from '@blueprintjs/core';
+import { Breadcrumb, NonIdealState } from '@blueprintjs/core';
 
 import DOSLayout from 'corla/component/DOSLayout';
 import FileDownloadButtons from 'corla/component/FileDownloadButtons';
@@ -26,30 +26,36 @@ function formatMember(member: AuditBoardMember): string {
     return `${firstName} ${lastName} (${party})`;
 }
 
-interface AuditBoardProps {
-    auditBoard: AuditBoardStatus;
+function formatAuditBoardRow(board: AuditBoardStatus) {
+    return (
+        <tr>
+            <td>{ formatMember(board.members[0]) }</td>
+            <td>{ formatMember(board.members[1]) }</td>
+            <td>{ `${board.signIn}` }</td>
+        </tr>
+    );
 }
 
-const AuditBoard = (props: AuditBoardProps) => {
-    const { auditBoard } = props;
+interface AuditBoardsProps {
+    auditBoards: AuditBoards;
+}
+
+const AuditBoards = (props: AuditBoardsProps) => {
+    const { auditBoards } = props;
 
     return (
         <div className='mt-default'>
-            <h3>Audit Board</h3>
+            <h3>Audit boards</h3>
             <table className='pt-html-table pt-html-table-striped rla-table'>
+                <thead>
+                    <tr>
+                        <th>Board member #1</th>
+                        <th>Board member #2</th>
+                        <th>Sign-in time</th>
+                    </tr>
+                </thead>
                 <tbody>
-                    <tr>
-                        <td><strong>Board Member #1:</strong></td>
-                        <td>{ formatMember(auditBoard.members[0]) }</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Board Member #2:</strong></td>
-                        <td>{ formatMember(auditBoard.members[1]) }</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Sign-in Time:</strong></td>
-                        <td>{ `${auditBoard.signIn}` }</td>
-                    </tr>
+                    { _.map(auditBoards, formatAuditBoardRow) }
                 </tbody>
             </table>
         </div>
@@ -59,8 +65,9 @@ const AuditBoard = (props: AuditBoardProps) => {
 const NoAuditBoard = () => {
     return (
         <div className='mt-default'>
-            <h3>Audit Board</h3>
-            <p>Audit Board not signed in.</p>
+            <h3>Audit boards</h3>
+            <NonIdealState title='Audit boards are not signed in.'
+                           visual='people' />
         </div>
     );
 };
@@ -72,7 +79,7 @@ interface DetailsProps {
 
 const CountyDetails = (props: DetailsProps) => {
     const { county, status } = props;
-    const { auditBoard } = status;
+    const { auditBoards } = status;
 
     const countyState = formatCountyASMState(status.asmState);
     const submitted = status.auditedBallotCount;
@@ -80,8 +87,8 @@ const CountyDetails = (props: DetailsProps) => {
     const auditedCount = _.get(status, 'discrepancyCount.audited') || '—';
     const unauditedCount = _.get(status, 'discrepancyCount.unaudited') || '—';
 
-    const auditBoardSection = auditBoard
-                            ? <AuditBoard auditBoard={ auditBoard } />
+    const auditBoardSection = auditBoards
+                            ? <AuditBoards auditBoards={ auditBoards } />
                             : <NoAuditBoard />;
 
     return (

--- a/client/src/component/DOS/County/OverviewPage.tsx
+++ b/client/src/component/DOS/County/OverviewPage.tsx
@@ -52,15 +52,11 @@ interface TableProps {
 const CountyTable = (props: TableProps) => {
     const { countyStatus } = props;
 
-    const countyRows = _.map(counties, c => {
-        const status = countyStatus[c.id];
-
-        if (!status) {
-            return <div key={ c.id } />;
-        }
-
-        return <CountyTableRow key={ c.id } county={ c } status={ status } />;
-    });
+    const countyRows = _
+        .chain(counties)
+        .filter((c: CountyInfo) => !!countyStatus[c.id])
+        .map(c => <CountyTableRow key={ c.id } county={ c } status={ countyStatus[c.id] } />)
+        .value();
 
     return (
         <table className='pt-html-table pt-html-table-striped rla-table mt-default'>

--- a/client/src/format.ts
+++ b/client/src/format.ts
@@ -63,9 +63,13 @@ export function formatCountyAndBoardASMState(countyStatus: DOS.CountyStatus): st
                 return 'Waiting for round start';
             }
         case 'ROUND_IN_PROGRESS':
-            return 'Round in progress';
         case 'ROUND_IN_PROGRESS_NO_AUDIT_BOARD':
-            if (countyStatus.auditBoardCount) {
+            // TODO: Counterintuitive, but on rounds past the first, the ASM
+            // state indicates the round is in progress when it should
+            // probably be WAITING_FOR_ROUND_START.
+            if (!countyStatus.auditBoardCount && _.isEmpty(countyStatus.auditBoards)) {
+                return 'Waiting for round start';
+            } else if (_.isEmpty(countyStatus.auditBoards)) {
                 return 'Audit board # is set';
             } else {
                 return 'Round in progress';
@@ -110,7 +114,11 @@ export function formatCountyAndBoardASMStateIndicator(countyStatus: DOS.CountySt
     case 'COUNTY_AUDIT_UNDERWAY': {
         switch (boardAsmState) {
         case 'ROUND_IN_PROGRESS':
-            return 'status-indicator-in-progress';
+            if (!_.isEmpty(countyStatus.auditBoards)) {
+                return 'status-indicator-in-progress';
+            } else {
+                return '';
+            }
         default:
             return '';
         }

--- a/client/src/types/dos.d.ts
+++ b/client/src/types/dos.d.ts
@@ -50,7 +50,7 @@ declare namespace DOS {
 
     interface CountyStatus {
         asmState: County.ASMState;
-        auditBoard: AuditBoardStatus;
+        auditBoards: AuditBoards;
         auditBoardASMState: AuditBoardASMState;
         auditBoardCount?: number;
         auditedBallotCount: number;


### PR DESCRIPTION
Also now handles audit board presence in subsequent rounds.

Resolves [#166386508](https://www.pivotaltracker.com/story/show/166386508).